### PR TITLE
Improve example docs

### DIFF
--- a/docs/examples/basic_auth.md
+++ b/docs/examples/basic_auth.md
@@ -6,6 +6,16 @@ It creates a nested `Ohkami` instance secured by the `BasicAuth` fang.  The oute
 server exposes a public `/hello` endpoint and a `/private` endpoint that requires
 the configured credentials.
 
+## Files
+
+- `src/main.rs` – configures a nested `Ohkami` protected by `BasicAuth`.
+
+### `src/main.rs`
+
+`private_ohkami` defines the secured portion with its own route. The outer
+`Ohkami` mounts both the public `/hello` and `/private/hello` which delegates to
+the inner application.
+
 Run it with:
 
 ```bash

--- a/docs/examples/chatgpt.md
+++ b/docs/examples/chatgpt.md
@@ -11,3 +11,16 @@ $ cargo run --example chatgpt -- --api-key <YOUR_KEY>
 ```
 
 POST a message to `/chat-once` and receive streamed chunks in real time.
+
+## Files
+
+- `src/main.rs` – contains the relay logic and defines the `/chat-once` route.
+- `src/fangs.rs` – loads the API key from the environment and inserts it into the
+  request context.
+- `src/models.rs` and `src/error.rs` – typed API payloads and error handling.
+
+### Flow
+
+1. `APIKey` fang attaches the OpenAI key to each request.
+2. `relay_chat_completion` forwards the request to the OpenAI endpoint and
+   returns a streaming `DataStream` of the response chunks.

--- a/docs/examples/derive_from_request.md
+++ b/docs/examples/derive_from_request.md
@@ -4,6 +4,16 @@ Illustrates implementing the `FromRequest` trait to extract custom types from an
 incoming request.  Four structs demonstrate different patterns for borrowing or
 owning pieces of the request such as the method and path.
 
+## Files
+
+- `src/main.rs` – defines several `FromRequest` implementations.
+
+### `src/main.rs`
+
+The example defines wrapper structs (`RequestMethod`, `RequestPath`, etc.) and
+derive macros (`MethodAndPathA`–`D`) showing how to borrow from or own pieces of
+the incoming request. There are no routes; compiling ensures the derives work.
+
 This is a compile‑time demo; run with:
 
 ```bash

--- a/docs/examples/form.md
+++ b/docs/examples/form.md
@@ -4,6 +4,17 @@ Shows how to receive multipart form data including uploaded files.  Submitting
 the provided `form.html` sends text and multiple images to the `/submit` route.
 A simple `Logger` fang prints each request and response for clarity.
 
+## Files
+
+- `src/main.rs` – form handler logic.
+- `form.html` – sample HTML form.
+
+### `src/main.rs`
+
+- `get_form` returns the HTML form on `/form`.
+- `post_submit` parses a multipart request at `/submit` and logs the result.
+- `Logger` fang shows incoming requests and outgoing responses in the console.
+
 Build and run:
 
 ```bash

--- a/docs/examples/hello.md
+++ b/docs/examples/hello.md
@@ -4,6 +4,17 @@ A slightly larger starter server with logging fangs and two routes:
 `/hc` for health checks and `/api` with query and JSON endpoints.  It also shows
 how to add custom response headers.
 
+## Files
+
+- `src/main.rs` – defines the routes and custom fangs used by the example.
+
+### `src/main.rs`
+
+- `health_handler` module – exposes `health_check` for `/hc`.
+- `hello_handler` module – provides query and JSON endpoints under `/api`.
+- `fangs` module – `LogRequest` and `SetServer` demonstrate custom request/response hooks.
+- `main` sets up the `Ohkami` tree combining these pieces and starts the server on `localhost:3000`.
+
 ```bash
 $ cargo run --example hello
 ```

--- a/docs/examples/html_layout.md
+++ b/docs/examples/html_layout.md
@@ -4,6 +4,17 @@ Uses the `uibeam` crate to compose a small HTML UI and wrap each response in a
 layout template.  Querying `/?init=5` shows a counter starting at 5 that can be
 incremented or decremented using simple JavaScript.
 
+## Files
+
+- `src/main.rs` – defines the `Layout` fang and a simple counter component.
+
+### `src/main.rs`
+
+- `Layout::fang_with_title` wraps HTML responses with a page template.
+- `Counter` is a UIbeam component rendering the interactive counter.
+- `index` handler reads an optional `init` query parameter and returns the
+  rendered page via `HTML`.
+
 Run:
 
 ```bash

--- a/docs/examples/json_response.md
+++ b/docs/examples/json_response.md
@@ -1,7 +1,18 @@
 # JSON Response Example
 
-Simple demonstration of returning typed JSON values.  Two endpoints return a
-single user object and an array of users respectively.
+Simple demonstration of returning typed JSON values.
+
+## Files
+
+- `Cargo.toml` – pulls in `ohkami`.
+- `src/main.rs` – implements the handlers.
+
+### `src/main.rs`
+
+Two handlers show how the `JSON` wrapper serializes Rust structs:
+
+- `single_user` – returns one `User` from `/single`.
+- `multiple_users` – returns a `Vec<User>` from `/multiple`.
 
 ```bash
 $ cargo run --example json_response

--- a/docs/examples/jwt.md
+++ b/docs/examples/jwt.md
@@ -4,6 +4,17 @@ Generates JSON Web Tokens and secures a private route using the `JWT` fang.
 Set `JWT_SECRET` in `.env` and run the example to obtain a token from `/auth`.
 Use that token in the `Authorization` header to access `/private`.
 
+## Files
+
+- `src/main.rs` – issues tokens and verifies them on a private route.
+- `.env.sample` – example of the required `JWT_SECRET` variable.
+
+### `src/main.rs`
+
+- `jwt()` builds the `JWT` fang with the configured secret.
+- `auth` returns a new token from `/auth`.
+- `private` demonstrates extracting the validated payload via `Context`.
+
 ```bash
 $ JWT_SECRET=mysecret cargo run --example jwt
 ```

--- a/docs/examples/multiple-single-threads.md
+++ b/docs/examples/multiple-single-threads.md
@@ -3,6 +3,16 @@
 Starts several single‑threaded Tokio runtimes listening on the same port.
 Useful for scaling CPU‑bound servers without a full multi‑threaded executor.
 
+## Files
+
+- `src/main.rs` – spawns multiple single-threaded Tokio runtimes.
+
+### `src/main.rs`
+
+`ohkami()` defines a tiny app with one route. The `main` function builds a TCP
+listener with port reuse enabled and then starts several runtimes, each calling
+`serve()` to accept connections on the same port.
+
 ```bash
 $ cargo run --example multiple-single-threads
 ```

--- a/docs/examples/quick_start.md
+++ b/docs/examples/quick_start.md
@@ -3,6 +3,18 @@
 The minimal server used in the README.  Includes a health check endpoint and
 parameterized hello route.  Perfect as a template for new services.
 
+## Files
+
+- `Cargo.toml` – declares the `ohkami` dependency.
+- `src/main.rs` – implements the handlers and server setup.
+
+### `src/main.rs`
+
+- `health_check` – returns a `NoContent` status for `/healthz`.
+- `hello` – greets the path parameter captured from `/hello/:name`.
+- the `main` function builds an `Ohkami` instance with the two routes and
+  listens on `localhost:3000`.
+
 ```bash
 $ cargo run --example quick_start
 ```

--- a/docs/examples/sse.md
+++ b/docs/examples/sse.md
@@ -3,6 +3,16 @@
 Streams a sequence of messages to the client using Ohkami's built‑in SSE
 support.  Each second another event is sent until the stream completes.
 
+## Files
+
+- `src/main.rs` – defines a single `/sse` route that returns `DataStream`.
+
+### `src/main.rs`
+
+`handler` creates a streaming response that emits five messages with a one
+second delay between them. The `main` function mounts this handler and listens
+on `localhost:3020`.
+
 ```bash
 $ cargo run --example sse
 ```

--- a/docs/examples/static_files.md
+++ b/docs/examples/static_files.md
@@ -4,6 +4,17 @@ Demonstrates the `Dir` fang for serving files from a directory.  Options enable
 hiding dotfiles, omitting `.html` extensions and using precompressed files when
 available.  Extensive tests cover the behavior under different settings.
 
+## Files
+
+- `src/main.rs` – configures the `Dir` fang and contains unit tests.
+- `public/` – folder of sample files, some of which have precompressed variants.
+
+### `src/main.rs`
+
+`ohkami()` builds an `Ohkami` instance based on provided `Options`.
+The main function simply calls `ohkami(Default::default())` to start a static
+file server on port 3000.
+
 ```bash
 $ cargo run --example static_files
 ```

--- a/docs/examples/websocket.md
+++ b/docs/examples/websocket.md
@@ -5,6 +5,20 @@ Several echo servers showcasing different ways to use WebSockets in Ohkami.
 `/echo3` demonstrates splitting the connection.  Static HTML templates are served
 from `template/` for testing with a browser.
 
+## Files
+
+- `src/main.rs` – contains four echo handlers and mounts the routes.
+- `template/index.html` – simple browser client for manual testing.
+
+### `src/main.rs`
+
+Each handler shows a different upgrade pattern:
+
+- `echo_text` – direct upgrade, sending back each received text frame.
+- `echo_text_2` – returns a type implementing `IntoResponse` for deferred upgrade.
+- `echo_text_3` – splits the socket and spawns tasks to manage read/write.
+- `echo4` – demonstrates spawning without awaiting the join handle.
+
 ```bash
 $ cargo run --example websocket
 ```


### PR DESCRIPTION
## Summary
- expand each example doc with file and function breakdowns

## Testing
- `bash test.sh` *(fails: failed to download crates index)*

------
https://chatgpt.com/codex/tasks/task_b_6854c64b006c832eb7f80fc7a29f0a8f