### PR TITLE
Add style and pattern docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,5 @@ For a hands-on introduction to Ohkami **v0.24**, check out the [start-up guide](
 
 For walkthroughs of the sample applications, see the guides in
 [docs/examples](docs/examples/README.md).
+
+For more style guidelines see [docs/CODE_STYLE_v0.24.md](docs/CODE_STYLE_v0.24.md) and the pattern notes in [docs/PATTERNS_v0.24.md](docs/PATTERNS_v0.24.md).

--- a/docs/CODE_STYLE_v0.24.md
+++ b/docs/CODE_STYLE_v0.24.md
@@ -1,0 +1,76 @@
+# Ohkami Code Style
+
+This guide summarizes common conventions seen in the `ohkami` source
+and examples for v0.24.  Following these patterns will keep your
+handlers and modules consistent with the official repository.
+
+## Modules
+
+Large examples group related handlers inside modules.  The
+`hello` example is a good template:
+
+```rust
+mod health_handler {
+    use ohkami::typed::status::NoContent;
+
+    pub async fn health_check() -> NoContent {
+        NoContent
+    }
+}
+
+mod hello_handler {
+    use ohkami::format::{Query, JSON};
+    use ohkami::serde::Deserialize;
+    // ...
+}
+```
+
+Handlers are defined in their own modules and imported in `main` when
+constructing the `Ohkami` instance.
+
+## Fangs
+
+Middleware implementations are called *fangs*.  A fang implements the
+`FangAction` trait.  The `hello` example defines `SetServer` and
+`LogRequest`:
+
+```rust
+#[derive(Clone)]
+pub struct SetServer;
+impl FangAction for SetServer {
+    fn back<'a>(&'a self, res: &'a mut Response)
+        -> impl std::future::Future<Output = ()> + Send
+    {
+        res.headers.set().Server("ohkami");
+        async {}
+    }
+}
+```
+
+Fangs are added in the routing tuple before the path definitions.
+
+## Handler Functions
+
+Handlers are asynchronous functions returning a type that implements
+`IntoResponse`.  The project sources document the signature rules
+explicitly:
+
+```text
+async ({path params}?, {FromRequest<'_> types}...) -> {IntoResponse type}
+```
+
+Handlers must be `Send` and `Sync` on native runtimes.  Parameter types
+implement `FromParam` or `FromRequest` as needed.
+
+## Typed Statuses
+
+HTTP status helpers are generated as types.  For example the
+`typed/status.rs` module defines constructors like `Created` and
+`NoContent`:
+
+```rust
+pub fn Created<B: IntoBody>(body: B) -> Created<B> { ... }
+```
+
+Use these instead of manual `Response` building to keep responses
+uniform and self documenting.

--- a/docs/PATTERNS_v0.24.md
+++ b/docs/PATTERNS_v0.24.md
@@ -1,0 +1,66 @@
+# Common Patterns
+
+This note collects useful idioms found throughout the v0.24 source
+code.  They can serve as guidelines when designing your own services.
+
+## Nesting Routes
+
+`Ohkami` instances can be nested with `Route::By`.  The inner app is
+mounted under a prefix:
+
+```rust
+Ohkami::new((
+    "/api".By(other_ohkami),
+))
+```
+
+The outer instance receives requests and delegates to the inner one.
+
+## Custom Extraction
+
+Implement `FromRequest` to pull values from the request.  The
+`derive_from_request` example demonstrates structs and tuples derived
+from request pieces:
+
+```rust
+#[derive(FromRequest)]
+struct MethodAndPathA {
+    method: RequestMethod,
+    path:   RequestPathOwned,
+}
+```
+
+`from_request` returns `Option<Result<T, E>>` so you may return `None`
+to skip extraction for a particular handler.
+
+## Middleware Composition
+
+Fangs are combined as tuples.  The internal `middleware` module defines
+`Fangs` for tuples up to eight elements.  When multiple fangs are
+present they wrap the handler in order:
+
+```rust
+(FangA, FangB, "/route".GET(handler))
+```
+
+Here `FangA` runs first, then `FangB`, and finally the handler.
+
+## Testing Without the Network
+
+The library provides a test harness that allows calling handlers without
+opening sockets.  Create the `Ohkami` instance and invoke
+`ohkami.testing::Test`:
+
+```rust
+let t = my_ohkami().test();
+let res = t.oneshot(TestRequest::GET("/hello")).await;
+```
+
+Responses can be inspected like normal `Response` values.
+
+## Typed Responses
+
+The `typed::status` module defines structs such as `Created` and
+`NoContent` for common status codes.  Construct these with or without a
+payload to clearly express handler results.
+


### PR DESCRIPTION
## Summary
- document code style conventions
- capture common patterns seen in the source
- reference new docs from the main README

## Testing
- `cargo check --lib --quiet` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_b_6854c85107fc832eb8a7920dbbca11e6