### PR TITLE
Add comprehensive coding guide and update docs

### DIFF
--- a/docs/CODE_STYLE_v0.24.md
+++ b/docs/CODE_STYLE_v0.24.md
@@ -49,6 +49,17 @@ impl FangAction for SetServer {
 
 Fangs are added in the routing tuple before the path definitions.
 
+### Builtin Fangs
+
+The [`fang::builtin`](../ohkami-0.24/ohkami/src/fang/builtin) module
+provides ready made middleware:
+
+- `Context` – store request scoped values.
+- `BasicAuth` – HTTP Basic authentication.
+- `JWT` – token based auth.
+- `CORS` – Cross‑Origin Resource Sharing headers.
+- `Timeout` – cancel slow requests on native runtimes.
+
 ## Handler Functions
 
 Handlers are asynchronous functions returning a type that implements

--- a/docs/CODING_GUIDE_v0.24.md
+++ b/docs/CODING_GUIDE_v0.24.md
@@ -1,0 +1,101 @@
+# Ohkami v0.24 Coding Guide
+
+This guide summarizes the main APIs found in the `ohkami` crate.  It pulls
+together examples from the repository and highlights useful patterns to get
+you productive quickly.
+
+## Creating an Application
+
+Construct an [`Ohkami`](../ohkami-0.24/ohkami/src/ohkami/mod.rs) by combining
+fangs (middleware) and route definitions:
+
+```rust
+use ohkami::prelude::*;
+use ohkami::typed::status;
+
+async fn health_check() -> status::NoContent {
+    status::NoContent
+}
+
+async fn hello(name: &str) -> String {
+    format!("Hello, {name}!")
+}
+
+#[tokio::main]
+async fn main() {
+    Ohkami::new((
+        "/healthz".GET(health_check),
+        "/hello/:name".GET(hello),
+    )).howl("localhost:3000").await;
+}
+```
+
+Routes are defined using chained methods on path literals.  Parameters are
+captured with `:` prefixes and passed to handlers by type.
+
+## Middleware – *Fangs*
+
+Fangs implement [`FangAction`](../ohkami-0.24/ohkami/src/fang/mod.rs) and can be
+registered globally or for individual handlers.  Built‑in fangs live in the
+[`fang::builtin`](../ohkami-0.24/ohkami/src/fang/builtin) module and include:
+
+- `Context` – attach request scoped data.
+- `BasicAuth` – simple username/password authentication.
+- `JWT` – JSON Web Token verification.
+- `CORS` – configure Cross‑Origin Resource Sharing headers.
+- `Timeout` – abort slow requests on native runtimes.
+
+Custom fangs are normal structs that implement the trait.
+
+```rust
+#[derive(Clone)]
+struct Log;
+impl FangAction for Log {
+    async fn fore<'a>(&'a self, req: &'a mut Request) -> Result<(), Response> {
+        println!("incoming: {} {}", req.method(), req.path());
+        Ok(())
+    }
+}
+
+Ohkami::new((Log, "/".GET(|| async {"hi"})));
+```
+
+## Typed Statuses and Responses
+
+The [`typed::status`](../ohkami-0.24/ohkami/src/typed/status.rs) module generates
+types such as `OK`, `Created` and `NoContent`.  Returning these makes handlers
+self‑documenting and ensures headers like `Content-Type` and
+`Content-Length` are set correctly.
+
+```rust
+use ohkami::typed::status;
+
+async fn create() -> status::Created<&'static str> {
+    status::Created("done")
+}
+```
+
+## Testing
+
+Use `ohkami::testing::Test` to invoke routes without opening sockets:
+
+```rust
+use ohkami::testing::*;
+
+let t = my_ohkami().test();
+let res = t.oneshot(TestRequest::GET("/hello")).await;
+assert_eq!(res.status(), Status::OK);
+```
+
+## Optional Features
+
+Ohkami exposes optional integrations enabled via Cargo features:
+
+- `openapi` – automatically generate an OpenAPI document with
+  [`Ohkami::generate`](../ohkami-0.24/ohkami/src/ohkami/mod.rs).
+- `sse` – send Server‑Sent Events using `DataStream`.
+- `ws` – handle WebSocket connections through `WebSocketContext`.
+- `tls` – serve HTTPS using `howls` with a `rustls` configuration.
+
+Consult the main [README](../ohkami-0.24/README.md) for more details and
+example code for each feature.

--- a/docs/PATTERNS_v0.24.md
+++ b/docs/PATTERNS_v0.24.md
@@ -64,3 +64,27 @@ The `typed::status` module defines structs such as `Created` and
 `NoContent` for common status codes.  Construct these with or without a
 payload to clearly express handler results.
 
+## Builtin Middleware
+
+Ohkami ships with several useful fangs that cover common needs.  They can
+be found under [`fang::builtin`](../ohkami-0.24/ohkami/src/fang/builtin):
+
+- `Context` for passing data between fangs and handlers.
+- `BasicAuth` and `JWT` for authentication.
+- `CORS` to add cross origin headers.
+- `Timeout` to stop long running requests.
+
+Combine them as needed when constructing your `Ohkami` instance.
+
+## Real‑time Features
+
+With the `sse` feature enabled an endpoint can stream
+Server‑Sent Events using `DataStream`.  The `ws` feature enables building
+WebSocket handlers via `WebSocketContext`.
+
+## OpenAPI Generation
+
+Enable the `openapi` feature to have `Ohkami` produce an OpenAPI document
+describing all routes.  Call `Ohkami::generate` or `generate_to` before
+starting the server to write `openapi.json`.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+# Ohkami v0.24 Documentation
+
+This directory collects learning material for the [Ohkami](https://github.com/ohkami-rs/ohkami) web framework.
+Use these guides when exploring version **0.24**.
+
+- [STARTUP_GUIDE_v0.24.md](STARTUP_GUIDE_v0.24.md) — installation and running your first server.
+- [CODING_GUIDE_v0.24.md](CODING_GUIDE_v0.24.md) — walkthrough of common APIs and patterns.
+- [CODE_STYLE_v0.24.md](CODE_STYLE_v0.24.md) — conventions used throughout the code base.
+- [PATTERNS_v0.24.md](PATTERNS_v0.24.md) — useful idioms taken from the implementation.
+- [examples/](examples/README.md) — documentation for the example projects.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -2,7 +2,8 @@
 
 This folder contains short guides for the example projects included with
 Ohkami **v0.24**. Each sub‑section explains what the example demonstrates and
-how to run it. Use these as building blocks when exploring the framework.
+how to run it.  If you are new to the framework start with the
+[coding guide](../CODING_GUIDE_v0.24.md) and then explore these examples.
 
 - [basic_auth.md](basic_auth.md)
 - [chatgpt.md](chatgpt.md)


### PR DESCRIPTION
## Summary
- create `docs/README.md` as an index of all documentation
- add `docs/CODING_GUIDE_v0.24.md` with API overview, fangs and features
- link to the new guide from examples README
- expand code style and patterns notes with builtin middleware and features

## Testing
- `cargo test --manifest-path ohkami-0.24/Cargo.toml` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_b_6854d168f2b8832e94b3094b6c94cef2