### PR TITLE
Add configuration info to docs

### DIFF
--- a/docs/CONFIGURATION_v0.24.md
+++ b/docs/CONFIGURATION_v0.24.md
@@ -1,0 +1,13 @@
+# Runtime Configuration
+
+Ohkami exposes a few environment variables to tweak runtime behavior when running on a native async runtime.
+These options are read at startup and apply to all servers.
+
+- `OHKAMI_REQUEST_BUFSIZE` – maximum size in bytes of the request buffer.
+  Defaults to **2048** bytes.
+- `OHKAMI_KEEPALIVE_TIMEOUT` – idle connection timeout in seconds before closing.
+  Defaults to **30** seconds.
+- `OHKAMI_WEBSOCKET_TIMEOUT` – WebSocket session timeout in seconds.
+  Defaults to **3600** seconds (1 hour) and only applies with the `ws` feature.
+
+Increase these values if clients send large headers or WebSocket connections should persist longer.

--- a/docs/PATTERNS_v0.24.md
+++ b/docs/PATTERNS_v0.24.md
@@ -88,3 +88,13 @@ Enable the `openapi` feature to have `Ohkami` produce an OpenAPI document
 describing all routes.  Call `Ohkami::generate` or `generate_to` before
 starting the server to write `openapi.json`.
 
+## Runtime Tuning
+
+Several behaviors can be adjusted via environment variables when using a native runtime:
+
+- `OHKAMI_REQUEST_BUFSIZE` – size of the internal request buffer.
+- `OHKAMI_KEEPALIVE_TIMEOUT` – seconds before an idle connection is closed.
+- `OHKAMI_WEBSOCKET_TIMEOUT` – lifetime of WebSocket sessions.
+
+Set these higher for large headers or long‑lived WebSocket connections.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,4 +7,5 @@ Use these guides when exploring version **0.24**.
 - [CODING_GUIDE_v0.24.md](CODING_GUIDE_v0.24.md) — walkthrough of common APIs and patterns.
 - [CODE_STYLE_v0.24.md](CODE_STYLE_v0.24.md) — conventions used throughout the code base.
 - [PATTERNS_v0.24.md](PATTERNS_v0.24.md) — useful idioms taken from the implementation.
+- [CONFIGURATION_v0.24.md](CONFIGURATION_v0.24.md) — environment variables and runtime tuning.
 - [examples/](examples/README.md) — documentation for the example projects.

--- a/docs/STARTUP_GUIDE_v0.24.md
+++ b/docs/STARTUP_GUIDE_v0.24.md
@@ -121,6 +121,17 @@ $ curl https://localhost:8443 --insecure
 Hello, secure ohkami!
 ```
 
+## Configuration
+
+Several environment variables adjust runtime behavior on native
+backends:
+
+- `OHKAMI_REQUEST_BUFSIZE` – request buffer size (default **2048** bytes).
+- `OHKAMI_KEEPALIVE_TIMEOUT` – keep‑alive timeout in seconds (default **30**).
+- `OHKAMI_WEBSOCKET_TIMEOUT` – WebSocket timeout in seconds (default **3600**).
+
+Increase these values if your service receives large headers or long‑lived WebSocket connections.
+
 ## Why Ohkami?
 
 - **Macro‑less APIs**: Intuitive and type‑safe route definitions.


### PR DESCRIPTION
## Summary
- document environment variables for runtime tuning
- link new configuration guide from docs README
- mention tuning options in Startup Guide and Patterns

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6854d7bd8da0832e916ab1480638e1c9