### PR TITLE
Add docs roadmap

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -1,0 +1,26 @@
+# Documentation Roadmap
+
+This roadmap tracks coverage of the Ohkami **v0.24** source code in the Markdown guides.
+It highlights which modules are documented and notes areas that still need work.
+
+## Well Covered
+
+- `ohkami/src/ohkami` – explained throughout [CODING_GUIDE_v0.24](CODING_GUIDE_v0.24.md).
+- `ohkami/src/fang` – builtin middleware referenced in [CODING_GUIDE_v0.24](CODING_GUIDE_v0.24.md) and [PATTERNS_v0.24](PATTERNS_v0.24.md).
+- `ohkami/src/testing` – usage described in both guides above.
+- `ohkami/src/tls` – setup instructions in [STARTUP_GUIDE_v0.24](STARTUP_GUIDE_v0.24.md).
+
+## Partially Documented
+
+- `format` and `header` modules appear in code snippets but lack detailed explanations.
+- `ws` and `sse` features are only touched on in examples.
+- `router` internals are mentioned briefly but not fully described.
+
+## Not Yet Covered
+
+- `session` handling APIs.
+- Cloud runtime adapters (`x_worker`, `x_lambda`).
+- Utility helpers under `util` and the `ohkami_lib` crate.
+- Procedural macros implemented in the `ohkami_macros` crate.
+
+Contributions are welcome!  Add notes or examples for any missing areas so both humans and LLMs can understand the framework more completely.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,4 +8,5 @@ Use these guides when exploring version **0.24**.
 - [CODE_STYLE_v0.24.md](CODE_STYLE_v0.24.md) — conventions used throughout the code base.
 - [PATTERNS_v0.24.md](PATTERNS_v0.24.md) — useful idioms taken from the implementation.
 - [CONFIGURATION_v0.24.md](CONFIGURATION_v0.24.md) — environment variables and runtime tuning.
+- [DOCS_ROADMAP.md](DOCS_ROADMAP.md) — what parts of the source have been documented so far.
 - [examples/](examples/README.md) — documentation for the example projects.


### PR DESCRIPTION
## Summary
- add a new `DOCS_ROADMAP.md` document describing which modules from v0.24 are covered
- link to the roadmap from the docs README

## Testing
- `cargo --version`

------
https://chatgpt.com/codex/tasks/task_b_6854dcbd9f50832eb572cc755f52a0b9