### PR TITLE
Add missing Ohkami v0.24 docs

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -10,17 +10,16 @@ It highlights which modules are documented and notes areas that still need work.
 - `ohkami/src/testing` – usage described in both guides above.
 - `ohkami/src/tls` – setup instructions in [STARTUP_GUIDE_v0.24](STARTUP_GUIDE_v0.24.md).
 
+- `ohkami/src/session` – lifecycle explained in [SESSION_v0.24](SESSION_v0.24.md).
+- Cloud runtime adapters (`x_worker`, `x_lambda`) documented in [RUNTIME_ADAPTERS_v0.24](RUNTIME_ADAPTERS_v0.24.md).
+- `util` helpers and the `ohkami_lib` crate covered in [UTILS_v0.24](UTILS_v0.24.md).
+- Procedural macros in [MACROS_v0.24](MACROS_v0.24.md).
+
 ## Partially Documented
 
 - `format` and `header` modules appear in code snippets but lack detailed explanations.
 - `ws` and `sse` features are only touched on in examples.
 - `router` internals are mentioned briefly but not fully described.
 
-## Not Yet Covered
-
-- `session` handling APIs.
-- Cloud runtime adapters (`x_worker`, `x_lambda`).
-- Utility helpers under `util` and the `ohkami_lib` crate.
-- Procedural macros implemented in the `ohkami_macros` crate.
 
 Contributions are welcome!  Add notes or examples for any missing areas so both humans and LLMs can understand the framework more completely.

--- a/docs/MACROS_v0.24.md
+++ b/docs/MACROS_v0.24.md
@@ -1,0 +1,22 @@
+# Procedural Macros
+
+The `ohkami_macros` crate implements several derive and attribute macros used throughout Ohkami.
+Source code lives under [`ohkami_macros/src`](../ohkami-0.24/ohkami_macros/src).
+
+## Serialization Helpers
+
+`Serialize` and `Deserialize` are thin re-exports of the matching `serde` derives. Use them when you want serialization without depending directly on `serde` in your crate.
+
+## Request Extraction
+
+`#[derive(FromRequest)]` generates implementations for extracting typed data from an incoming `Request`. Structs composed of other `FromRequest` types can use this derive to bundle multiple parameters together.
+
+## OpenAPI Integration
+
+With the `openapi` feature enabled, `#[derive(Schema)]` and the `#[operation]` attribute generate OpenAPI schemas and operation metadata from your types and handler functions.
+
+## Cloudflare Workers Support
+
+When targeting Cloudflare Workers, the `worker` attribute connects an `async` function as the entry point and `DurableObject` marks a struct for use with Durable Objects. These rely on the `worker` runtime crate.
+
+These macros reduce boilerplate and keep your application code focused on business logic.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,11 @@ Use these guides when exploring version **0.24**.
 - [CODING_GUIDE_v0.24.md](CODING_GUIDE_v0.24.md) — walkthrough of common APIs and patterns.
 - [CODE_STYLE_v0.24.md](CODE_STYLE_v0.24.md) — conventions used throughout the code base.
 - [PATTERNS_v0.24.md](PATTERNS_v0.24.md) — useful idioms taken from the implementation.
+- [SESSION_v0.24.md](SESSION_v0.24.md) — how connections are managed.
+- [RUNTIME_ADAPTERS_v0.24.md](RUNTIME_ADAPTERS_v0.24.md) — deploying to Workers or Lambda.
+- [UTILS_v0.24.md](UTILS_v0.24.md) — helper functions and utility crate.
+- [MACROS_v0.24.md](MACROS_v0.24.md) — derive and attribute macros.
+
 - [CONFIGURATION_v0.24.md](CONFIGURATION_v0.24.md) — environment variables and runtime tuning.
 - [DOCS_ROADMAP.md](DOCS_ROADMAP.md) — what parts of the source have been documented so far.
 - [examples/](examples/README.md) — documentation for the example projects.

--- a/docs/RUNTIME_ADAPTERS_v0.24.md
+++ b/docs/RUNTIME_ADAPTERS_v0.24.md
@@ -1,0 +1,20 @@
+# Cloud Runtime Adapters
+
+Ohkami can run inside serverless environments through optional adapters. These live in [`x_worker.rs`](../ohkami-0.24/ohkami/src/x_worker.rs) and [`x_lambda.rs`](../ohkami-0.24/ohkami/src/x_lambda.rs).
+
+## Cloudflare Workers
+
+Enabling the `rt_worker` feature exposes utilities for the [workers-rs](https://github.com/cloudflare/workers-rs) runtime:
+
+- Procedural macros `#[worker]` and `#[DurableObject]` connect Ohkami routes to Cloudflare entry points.
+- The `FromEnv` trait lets you extract bindings (KV stores, queues, etc.) from the worker environment.
+- Durable Objects implement a trait with async hooks like `fetch`, `websocket_message`, and `alarm`.
+
+See the inline examples in `x_worker.rs` for a full setup.
+
+## AWS Lambda
+
+When built with the `rt_lambda` feature Ohkami integrates with `lambda_runtime` through types in `x_lambda.rs`.
+It defines `LambdaHTTPRequest` and `LambdaResponse` structs compatible with API Gateway and provides a basic WebSocket client for AWS' WebSocket APIs. An adapter to map between Lambda events and Ohkami `Request`/`Response` types is planned but not yet finalized.
+
+These modules allow deploying the same application logic to native servers or serverless platforms with minimal changes.

--- a/docs/SESSION_v0.24.md
+++ b/docs/SESSION_v0.24.md
@@ -1,0 +1,14 @@
+# Session Handling
+
+Ohkami processes each network connection through a `Session` struct. The implementation lives in [`ohkami/src/session`](../ohkami-0.24/ohkami/src/session/mod.rs).
+
+A session owns the underlying TCP stream (or other runtime connection type) and drives the request/response loop. It applies a keep‑alive timeout between reads and routes each request through the shared `Router`. When the `ws` feature is enabled, a successful upgrade switches the session over to `WebSocket` management.
+
+Key behaviors:
+
+- Reads requests with `timeout_in` so idle connections close after `OHKAMI_KEEPALIVE_TIMEOUT` seconds.
+- Catches panics from handlers and converts them into `500` responses.
+- Logs connection errors and broken pipes with the utility macros from [`util`](../ohkami-0.24/ohkami/src/util.rs).
+- When upgraded to a WebSocket, delegates to `ws::WebSocket` with its own timeout (`OHKAMI_WEBSOCKET_TIMEOUT`).
+
+The session module is internal but understanding it helps when customizing runtimes or debugging low‑level behavior.

--- a/docs/UTILS_v0.24.md
+++ b/docs/UTILS_v0.24.md
@@ -1,0 +1,25 @@
+# Utility Helpers
+
+Several small helpers live under [`ohkami/src/util.rs`](../ohkami-0.24/ohkami/src/util.rs) and the companion [`ohkami_lib` crate](../ohkami-0.24/ohkami_lib). They provide functionality used across the framework but are also handy in applications.
+
+## Logging Macros
+
+- `INFO!`, `WARNING!`, `ERROR!` and `DEBUG!` print messages consistently whether running natively or in Cloudflare Workers.
+- `push_unchecked!` quickly appends bytes onto a `Vec<u8>`.
+
+## Data Utilities
+
+- Base64 helpers: `base64_encode`, `base64_decode`, and URL‑safe variants.
+- `iter_cookies` parses a raw `Cookie` header into `(name, value)` pairs.
+- `unix_timestamp` returns the current Unix time and works in both native and worker environments.
+- `timeout_in` wraps a future with a timeout when using native runtimes.
+
+## ohkami_lib Crate
+
+The `ohkami_lib` crate re-exports small utilities used by the framework:
+
+- `TupleMap` – a small vector-backed map for a handful of key/value pairs.
+- Percent‑encoding helpers: `percent_encode`, `percent_decode`, and `percent_decode_utf8`.
+- Modules under `serde_*` implement custom (de)serialization for cookies, multipart forms, URL encoding and more.
+
+These helpers keep Ohkami lightweight while avoiding extra dependencies in user code.


### PR DESCRIPTION
## Summary
- document the Session lifecycle
- document Cloudflare Worker and Lambda runtime adapters
- add a utilities overview and macro documentation
- link new docs from README
- update roadmap to reflect covered modules

## Testing
- `cargo check` *(fails: unable to access crates.io)*

------
https://chatgpt.com/codex/tasks/task_b_6854dead2c28832e9b832e2e572852ab