### PR TITLE
Add additional module docs

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -17,9 +17,9 @@ It highlights which modules are documented and notes areas that still need work.
 
 ## Partially Documented
 
-- `format` and `header` modules appear in code snippets but lack detailed explanations.
-- `ws` and `sse` features are only touched on in examples.
-- `router` internals are mentioned briefly but not fully described.
+- `format`, `header`, `ws`, `sse` and the router internals now each have short
+  descriptions in dedicated Markdown files.
+- The `ohkami_openapi` crate is still undocumented.
 
 
 Contributions are welcome!  Add notes or examples for any missing areas so both humans and LLMs can understand the framework more completely.

--- a/docs/FORMAT_v0.24.md
+++ b/docs/FORMAT_v0.24.md
@@ -1,0 +1,35 @@
+# Request and Response Formats
+
+Ohkami defines `FromBody` and `IntoBody` traits for converting between raw bytes
+and Rust types.  The [`format`](../ohkami-0.24/ohkami/src/format) module contains
+common implementations so handlers can work with strongly typed data without
+manual parsing.
+
+## Built‑In Types
+
+The `builtin` submodule covers the typical web formats:
+
+- **Query** – deserialize query strings into a struct.
+- **JSON** – parse `application/json` payloads with `serde_json`.
+- **URLEncoded** – form encoding for `application/x-www-form-urlencoded`.
+- **Multipart** – handle `multipart/form-data` uploads.  Files are represented by
+  the `File` helper.
+- **Text** – plain UTF‑8 bodies.
+- **HTML** – convenience wrapper for returning HTML responses.
+
+Each type implements both `FromBody` and `IntoBody` so they can be used for
+request extraction and response generation.  With the `openapi` feature enabled
+these types also provide schema information for documentation.
+
+## Custom Formats
+
+Applications can define their own structures by implementing the two traits.
+`FromBody` specifies a `MIME_TYPE` and a conversion from `&[u8]` while
+`IntoBody` supplies the outgoing `CONTENT_TYPE` and a method to serialize to
+bytes.
+
+See the source files under `format/builtin/` for simple examples of these
+traits in action.
+
+
+

--- a/docs/HEADERS_v0.24.md
+++ b/docs/HEADERS_v0.24.md
@@ -1,0 +1,38 @@
+# Working with Headers
+
+The [`header`](../ohkami-0.24/ohkami/src/header) module provides helpers for
+common HTTP header values.  These utilities simplify parsing and building
+headers so you rarely need to manipulate strings directly.
+
+## Append Helper
+
+`append` allows combining values when setting a header:
+
+```rust
+res.headers.set().Server(append("ohkami"));
+```
+
+Multiple calls join the values with commas according to the HTTP spec.
+
+## Cookie Builder
+
+`SetCookie` exposes a builder style API for generating `Set-Cookie` headers.
+All attributes like `MaxAge`, `Domain`, `Secure` and `SameSite` are optional and
+can be chained.
+
+```rust
+res.headers.set().SetCookie("id", "42", |c| c.Path("/").SameSiteLax());
+```
+
+## Entity Tags
+
+`ETag` parses strong and weak entity tags.  Use `ETag::parse` or the iterator
+helpers to process conditional request headers.
+
+## Content Encoding
+
+`Encoding` and `CompressionEncoding` represent compression algorithms. The
+`AcceptEncoding` struct sorts algorithms by quality values (`QValue`) so you can
+negotiate compressed responses.
+
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,11 @@ Use these guides when exploring version **0.24**.
 - [RUNTIME_ADAPTERS_v0.24.md](RUNTIME_ADAPTERS_v0.24.md) — deploying to Workers or Lambda.
 - [UTILS_v0.24.md](UTILS_v0.24.md) — helper functions and utility crate.
 - [MACROS_v0.24.md](MACROS_v0.24.md) — derive and attribute macros.
+- [FORMAT_v0.24.md](FORMAT_v0.24.md) — request/response body helpers.
+- [HEADERS_v0.24.md](HEADERS_v0.24.md) — common header utilities.
+- [WS_v0.24.md](WS_v0.24.md) — upgrading connections to WebSockets.
+- [SSE_v0.24.md](SSE_v0.24.md) — streaming Server‑Sent Events.
+- [ROUTER_v0.24.md](ROUTER_v0.24.md) — how routes are organized internally.
 
 - [CONFIGURATION_v0.24.md](CONFIGURATION_v0.24.md) — environment variables and runtime tuning.
 - [DOCS_ROADMAP.md](DOCS_ROADMAP.md) — what parts of the source have been documented so far.

--- a/docs/ROUTER_v0.24.md
+++ b/docs/ROUTER_v0.24.md
@@ -1,0 +1,17 @@
+# Router Internals
+
+Routing logic lives in [`router`](../ohkami-0.24/ohkami/src/router).  A tree of
+`Node` structures represents path segments for each HTTP method.  Handlers are
+registered with a path like `/api/users/:id` which creates nested nodes for the
+static and parameter segments.
+
+During startup the router is finalized into a lookup table.  Incoming requests
+traverse the tree matching segments until reaching a handler.  Middleware (fangs)
+registered at higher levels are collected along the way and wrap the handler in
+order.
+
+Understanding this structure helps when reading error messages about conflicting
+routes or parameter counts.  The public APIs hide these details but the source is
+useful if you need to debug complex route setups.
+
+

--- a/docs/SSE_v0.24.md
+++ b/docs/SSE_v0.24.md
@@ -1,0 +1,20 @@
+# Server‑Sent Events
+
+The `sse` feature provides the [`DataStream`](../ohkami-0.24/ohkami/src/sse)
+response type for sending event streams over HTTP.  Each item must implement the
+`Data` trait which converts it to a string.
+
+```rust
+async fn handler() -> DataStream {
+    DataStream::new(|mut s| async move {
+        s.send("start");
+        // push events asynchronously
+    })
+}
+```
+
+`DataStream` wraps any `Stream<Item = T>` where `T: Data`.  Calling
+`DataStream::new` spawns an async producer with a queue.  The response is sent
+with `content-type: text/event-stream`.
+
+

--- a/docs/WS_v0.24.md
+++ b/docs/WS_v0.24.md
@@ -1,0 +1,23 @@
+# WebSocket Support
+
+With the `ws` feature enabled Ohkami can upgrade HTTP connections to WebSockets.
+The [`ws`](../ohkami-0.24/ohkami/src/ws) module defines `WebSocketContext` for
+performing the handshake and `WebSocket` as the response type.
+
+```rust
+async fn handler(ctx: WebSocketContext<'_>) -> WebSocket {
+    ctx.upgrade(|mut conn| async move {
+        conn.send("hello").await.expect("send failed");
+    })
+}
+```
+
+Handlers receive a context extracted from the request. Calling `.upgrade` or
+`.upgrade_with` returns a `WebSocket` response that completes the handshake and
+runs the provided async closure.
+
+On native runtimes connections time out after `OHKAMI_WEBSOCKET_TIMEOUT` seconds
+(default 3600).  The returned `Connection` can be split into read and write
+halves for concurrent tasks.
+
+


### PR DESCRIPTION
## Summary
- document built-in body formats
- explain header utilities
- add guides for WebSocket, SSE, and Router internals
- update README links
- update docs roadmap with newly covered modules

## Testing
- `cargo check -p ohkami_lib` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_b_6854e25e0574832ebd397108465d2393