### PR TITLE
Expand ohkami v0.24 docs

### DIFF
--- a/docs/ARCHITECTURE_v0.24.md
+++ b/docs/ARCHITECTURE_v0.24.md
@@ -1,0 +1,42 @@
+# Ohkami v0.24 Architecture
+
+This overview explains how the framework is organized inside the `ohkami` crate so developers know where to look when exploring the source.
+
+## Crate Layout
+
+```
+ohkami/
+  src/
+    config.rs        - runtime configuration from environment
+    fang/            - middleware traits and builtins
+    format/          - body extractors and serializers
+    header/          - helpers for HTTP header values
+    ohkami/          - `Ohkami` type and routing utilities
+    request/         - parsing HTTP requests
+    response/        - building responses
+    router/          - tree based router implementation
+    session/         - connection handling loop
+    sse/             - Server‑Sent Event helpers (feature `sse`)
+    tls/             - TLS stream adapter (feature `tls`)
+    typed/           - typed status codes and header extraction
+    util.rs          - misc utilities used by the framework
+    ws/              - WebSocket support (feature `ws`)
+    testing/         - in memory test harness
+    x_worker.rs      - Cloudflare Workers adapter (feature `rt_worker`)
+    x_lambda.rs      - AWS Lambda adapter (feature `rt_lambda`)
+```
+
+Additional crates in the workspace include `ohkami_macros` for procedural macros, `ohkami_lib` with lightweight helpers and `ohkami_openapi` for OpenAPI generation.
+
+## Request Flow
+
+Incoming connections are accepted by a runtime specific server. Each socket is wrapped in a `Session` which reads requests using the buffer size and timeouts defined in [`config.rs`](../ohkami-0.24/ohkami/src/config.rs). A parsed [`Request`](../ohkami-0.24/ohkami/src/request/mod.rs) is passed to the router which locates the matching route and any attached *fangs*. Fangs run before and/or after the handler to implement middleware behaviors. The handler returns a [`Response`](../ohkami-0.24/ohkami/src/response/mod.rs) which is written back to the connection.
+
+Optional features extend this flow:
+
+- `ws` upgrades a request to a WebSocket handled by [`ws::WebSocket`](../ohkami-0.24/ohkami/src/ws).
+- `sse` streams events using [`sse::DataStream`](../ohkami-0.24/ohkami/src/sse).
+- `tls` wraps the TCP stream in a [`TlsStream`](../ohkami-0.24/ohkami/src/tls/mod.rs).
+- `openapi` generates documentation via `ohkami_openapi`.
+
+Understanding this structure helps navigate the source code and customize pieces for your own projects.

--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -9,6 +9,8 @@ It highlights which modules are documented and notes areas that still need work.
 - `ohkami/src/fang` – builtin middleware referenced in [CODING_GUIDE_v0.24](CODING_GUIDE_v0.24.md) and [PATTERNS_v0.24](PATTERNS_v0.24.md).
 - `ohkami/src/testing` – usage described in both guides above.
 - `ohkami/src/tls` – setup instructions in [STARTUP_GUIDE_v0.24](STARTUP_GUIDE_v0.24.md).
+- `ohkami/src/request` and `ohkami/src/response` – detailed in [REQUEST_v0.24](REQUEST_v0.24.md) and [RESPONSE_v0.24](RESPONSE_v0.24.md).
+- `ohkami/src/typed` – explained in [TYPED_v0.24](TYPED_v0.24.md).
 
 - `ohkami/src/session` – lifecycle explained in [SESSION_v0.24](SESSION_v0.24.md).
 - Cloud runtime adapters (`x_worker`, `x_lambda`) documented in [RUNTIME_ADAPTERS_v0.24](RUNTIME_ADAPTERS_v0.24.md).
@@ -18,7 +20,8 @@ It highlights which modules are documented and notes areas that still need work.
 ## Partially Documented
 
 - `format`, `header`, `ws`, `sse` and the router internals now each have short
-  descriptions in dedicated Markdown files.
+  descriptions in dedicated Markdown files. More real‑world examples would still
+  be valuable.
 - The `ohkami_openapi` crate is still undocumented.
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,12 +7,18 @@ Use these guides when exploring version **0.24**.
 - [CODING_GUIDE_v0.24.md](CODING_GUIDE_v0.24.md) — walkthrough of common APIs and patterns.
 - [CODE_STYLE_v0.24.md](CODE_STYLE_v0.24.md) — conventions used throughout the code base.
 - [PATTERNS_v0.24.md](PATTERNS_v0.24.md) — useful idioms taken from the implementation.
+- [ARCHITECTURE_v0.24.md](ARCHITECTURE_v0.24.md) — overview of crate modules.
 - [SESSION_v0.24.md](SESSION_v0.24.md) — how connections are managed.
 - [RUNTIME_ADAPTERS_v0.24.md](RUNTIME_ADAPTERS_v0.24.md) — deploying to Workers or Lambda.
 - [UTILS_v0.24.md](UTILS_v0.24.md) — helper functions and utility crate.
 - [MACROS_v0.24.md](MACROS_v0.24.md) — derive and attribute macros.
 - [FORMAT_v0.24.md](FORMAT_v0.24.md) — request/response body helpers.
 - [HEADERS_v0.24.md](HEADERS_v0.24.md) — common header utilities.
+- [REQUEST_v0.24.md](REQUEST_v0.24.md) — request structure and extraction.
+- [RESPONSE_v0.24.md](RESPONSE_v0.24.md) — building responses.
+- [TYPED_v0.24.md](TYPED_v0.24.md) — typed statuses and headers.
+- [TLS_v0.24.md](TLS_v0.24.md) — HTTPS support.
+- [TESTING_v0.24.md](TESTING_v0.24.md) — running handlers without sockets.
 - [WS_v0.24.md](WS_v0.24.md) — upgrading connections to WebSockets.
 - [SSE_v0.24.md](SSE_v0.24.md) — streaming Server‑Sent Events.
 - [ROUTER_v0.24.md](ROUTER_v0.24.md) — how routes are organized internally.

--- a/docs/REQUEST_v0.24.md
+++ b/docs/REQUEST_v0.24.md
@@ -1,0 +1,32 @@
+# HTTP Request Structure
+
+[`Request`](../ohkami-0.24/ohkami/src/request/mod.rs) represents an incoming HTTP request. It is constructed by the `Session` after parsing the method line and headers.
+
+Fields include:
+
+- `method: Method` – parsed from the request line.
+- `path: Path` – holds the URL path and provides access to parameters.
+- `query: QueryParams` – simple key/value map for query strings.
+- `headers: RequestHeaders` – parsed header fields with helper methods.
+- `payload: Option<CowSlice>` – body bytes if a `Content-Length` is present.
+- `context: Context` – per‑request storage for fangs and handlers.
+- `ip: std::net::IpAddr` – remote peer address on native runtimes.
+
+The module also defines the [`FromRequest`](../ohkami-0.24/ohkami/src/request/from_request.rs) trait which allows extracting custom types from a request. Handlers can accept any number of `FromRequest` values and the framework handles failures by returning an appropriate `Response`.
+
+Example fang logging requests:
+
+```rust,no_run
+use ohkami::prelude::*;
+
+#[derive(Clone)]
+struct Log;
+impl FangAction for Log {
+    async fn fore<'a>(&'a self, req: &'a mut Request) -> Result<(), Response> {
+        println!("{} {}", req.method, req.path.str());
+        Ok(())
+    }
+}
+```
+
+See the comments in `request/mod.rs` for additional details on payload limits and path parameter parsing.

--- a/docs/RESPONSE_v0.24.md
+++ b/docs/RESPONSE_v0.24.md
@@ -1,0 +1,26 @@
+# HTTP Responses
+
+The [`response`](../ohkami-0.24/ohkami/src/response) module defines the [`Response`](../ohkami-0.24/ohkami/src/response/mod.rs) type returned from handlers.
+A response is composed of a status code, headers and an optional body.
+
+Key pieces:
+
+- `Status` enum – common HTTP status codes with helper constructors.
+- `ResponseHeaders` – strongly typed header map with `SetHeaders` builder.
+- `Content` enum – body variant used internally (`None`, `Payload`, `Stream`, `WebSocket`).
+- `IntoResponse` trait – convert errors or other types into `Response` values.
+
+Typical usage inside a handler:
+
+```rust
+use ohkami::{Response, Status};
+
+async fn handler() -> Response {
+    Response::new(Status::OK).with_text("Hello")
+}
+```
+
+Middleware can modify headers by calling `res.headers.set()` in their `back` method.
+When the `sse` feature is active a handler may return a streaming body and the framework handles chunked encoding automatically.
+
+Review the documentation comments in `response/mod.rs` for details on WebSocket and SSE support.

--- a/docs/TESTING_v0.24.md
+++ b/docs/TESTING_v0.24.md
@@ -1,0 +1,23 @@
+# Testing Helpers
+
+Under debug builds Ohkami exposes a lightweight test harness in the [`testing`](../ohkami-0.24/ohkami/src/testing/mod.rs) module. It allows exercising routes without opening sockets.
+
+Create your application and call `.test()` on it to get a `TestingOhkami` instance. Use `TestRequest` to build requests and `.oneshot()` to execute them.
+
+```rust
+use ohkami::prelude::*;
+use ohkami::testing::*;
+
+fn app() -> Ohkami {
+    Ohkami::new( "/".GET(|| async { "hi" }) )
+}
+
+#[tokio::test]
+async fn test_index() {
+    let res = app().test().oneshot(TestRequest::GET("/")).await;
+    assert_eq!(res.status(), Status::OK);
+    assert_eq!(res.text(), Some("hi"));
+}
+```
+
+`TestRequest` supports adding query parameters, headers and JSON bodies for exercising your handlers.

--- a/docs/TLS_v0.24.md
+++ b/docs/TLS_v0.24.md
@@ -1,0 +1,24 @@
+# TLS Support
+
+Feature `tls` enables HTTPS servers using [rustls](https://github.com/rustls). The implementation wraps a TCP stream in [`TlsStream`](../ohkami-0.24/ohkami/src/tls/mod.rs) which implements the `Connection` trait used by `Session`.
+
+To run a server over TLS call `howls` instead of `howl` and provide a configured `ServerConfig`:
+
+```rust,no_run
+use ohkami::prelude::*;
+use rustls::ServerConfig;
+
+#[tokio::main]
+async fn main() {
+    let tls_config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(load_certs(), load_key())
+        .expect("TLS config");
+
+    Ohkami::new( (
+        "/".GET(|| async {"secure"})
+    )).howls("0.0.0.0:8443", tls_config).await;
+}
+```
+
+Currently TLS only works with the `rt_tokio` runtime and HTTP/1.1. See the README in `ohkami-0.24` for a complete example including certificate loading.

--- a/docs/TYPED_v0.24.md
+++ b/docs/TYPED_v0.24.md
@@ -1,0 +1,21 @@
+# Typed Utilities
+
+The [`typed`](../ohkami-0.24/ohkami/src/typed) module provides common HTTP pieces as strongly typed structs.
+
+## Status Types
+
+`typed::status` defines functions like `OK`, `Created`, and `NoContent` which return wrappers implementing `IntoResponse`. Returning these from handlers ensures consistent headers and is clearer than manually constructing a `Response`.
+
+```rust
+use ohkami::typed::status;
+
+async fn created() -> status::Created<&'static str> {
+    status::Created("ok")
+}
+```
+
+## Header Extraction
+
+`typed::header` declares the `FromHeader` trait used to parse custom types from request headers. When the `openapi` feature is enabled these types also implement `Schema` for documentation generation.
+
+Implement `FromHeader` for your own structs to automatically fail the request when parsing fails.


### PR DESCRIPTION
## Summary
- add architecture overview
- document Request and Response modules
- add TLS, typed utilities and testing notes
- link new docs from README and update roadmap

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6854e3f23528832eba0ec35a633e3866