### PR TITLE
Improve Ohkami docs

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -16,13 +16,13 @@ It highlights which modules are documented and notes areas that still need work.
 - Cloud runtime adapters (`x_worker`, `x_lambda`) documented in [RUNTIME_ADAPTERS_v0.24](RUNTIME_ADAPTERS_v0.24.md).
 - `util` helpers and the `ohkami_lib` crate covered in [UTILS_v0.24](UTILS_v0.24.md).
 - Procedural macros in [MACROS_v0.24](MACROS_v0.24.md).
+- `ohkami_openapi` documented in [OPENAPI_v0.24](OPENAPI_v0.24.md).
 
 ## Partially Documented
 
 - `format`, `header`, `ws`, `sse` and the router internals now each have short
   descriptions in dedicated Markdown files. More real‑world examples would still
   be valuable.
-- The `ohkami_openapi` crate is still undocumented.
 
 
 Contributions are welcome!  Add notes or examples for any missing areas so both humans and LLMs can understand the framework more completely.

--- a/docs/FORMAT_v0.24.md
+++ b/docs/FORMAT_v0.24.md
@@ -28,8 +28,15 @@ Applications can define their own structures by implementing the two traits.
 `IntoBody` supplies the outgoing `CONTENT_TYPE` and a method to serialize to
 bytes.
 
+For JSON data most handlers accept or return `format::JSON<T>` where `T` is a
+`serde` serializable type.  Multipart uploads expose files using the `File`
+struct which includes filename and content type metadata.  If you need a custom
+encoding such as protocol buffers implement both traits and you can seamlessly
+use the type in request parameters or responses.
+
 See the source files under `format/builtin/` for simple examples of these
 traits in action.
+
 
 
 

--- a/docs/HEADERS_v0.24.md
+++ b/docs/HEADERS_v0.24.md
@@ -35,4 +35,10 @@ helpers to process conditional request headers.
 `AcceptEncoding` struct sorts algorithms by quality values (`QValue`) so you can
 negotiate compressed responses.
 
+Typed helpers exist for many common headers.  For example `ResponseHeaders` has
+methods like `ContentType` and `CacheControl` which accept strongly typed
+wrappers.  Implement `FromHeader` for your own types to parse custom headers on
+incoming requests.
+
+
 

--- a/docs/MACROS_v0.24.md
+++ b/docs/MACROS_v0.24.md
@@ -19,4 +19,12 @@ With the `openapi` feature enabled, `#[derive(Schema)]` and the `#[operation]` a
 
 When targeting Cloudflare Workers, the `worker` attribute connects an `async` function as the entry point and `DurableObject` marks a struct for use with Durable Objects. These rely on the `worker` runtime crate.
 
+`#[bindings]` reads your `wrangler.toml` and generates a struct containing Cloudflare
+environment bindings.  This removes boilerplate when accessing KV stores or other
+resources from Workers code.
+
+The internal `consume_struct` macro is used by some derives and generally is not
+needed directly by applications.
+
 These macros reduce boilerplate and keep your application code focused on business logic.
+

--- a/docs/OPENAPI_v0.24.md
+++ b/docs/OPENAPI_v0.24.md
@@ -1,0 +1,63 @@
+# OpenAPI Support
+
+The optional `openapi` feature integrates specification generation directly into Ohkami.
+It builds on the `ohkami_openapi` crate and a set of procedural macros.
+
+With the feature enabled you can annotate data structures with
+`#[derive(openapi::Schema)]` and mark handlers using the `#[openapi::operation]`
+attribute.  When an application calls `Ohkami::generate` the router walks all
+registered routes and produces an `openapi.json` file describing the API.
+
+```rust,ignore
+use ohkami::prelude::*;
+use ohkami::typed::status;
+use ohkami::openapi;
+
+#[derive(Deserialize, openapi::Schema)]
+struct CreateUser<'req> {
+    name: &'req str,
+}
+
+#[derive(Serialize, openapi::Schema)]
+#[openapi(component)]
+struct User {
+    id: usize,
+    name: String,
+}
+
+#[openapi::operation({ summary: "create a new user" })]
+async fn create_user(
+    JSON(CreateUser { name }): JSON<CreateUser<'_>>
+) -> status::Created<JSON<User>> {
+    status::Created(JSON(User { id: 42, name: name.to_string() }))
+}
+
+async fn list_users() -> JSON<Vec<User>> {
+    JSON(vec![])
+}
+
+fn app() -> Ohkami {
+    Ohkami::new((
+        "/users".GET(list_users).POST(create_user)
+    ))
+}
+
+#[tokio::main]
+async fn main() {
+    let o = app();
+    o.generate(openapi::OpenAPI {
+        title:   "Users API",
+        version: "0.1.0",
+        servers: &[openapi::Server::at("localhost:5000")],
+    });
+    o.howl("localhost:5000").await;
+}
+```
+
+`generate_to` writes the document to an arbitrary path.  On Cloudflare Workers
+use the `scripts/workers_openapi.js` helper to run this logic outside of the
+`wasm32` environment.
+
+The resulting JSON follows the OpenAPI 3.1 specification and includes schemas,
+parameters, request bodies and responses extracted from your handlers.  Manual
+edits are rarely necessary once the macros are in place.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Use these guides when exploring version **0.24**.
 - [REQUEST_v0.24.md](REQUEST_v0.24.md) — request structure and extraction.
 - [RESPONSE_v0.24.md](RESPONSE_v0.24.md) — building responses.
 - [TYPED_v0.24.md](TYPED_v0.24.md) — typed statuses and headers.
+- [OPENAPI_v0.24.md](OPENAPI_v0.24.md) — generating OpenAPI documentation.
 - [TLS_v0.24.md](TLS_v0.24.md) — HTTPS support.
 - [TESTING_v0.24.md](TESTING_v0.24.md) — running handlers without sockets.
 - [WS_v0.24.md](WS_v0.24.md) — upgrading connections to WebSockets.

--- a/docs/REQUEST_v0.24.md
+++ b/docs/REQUEST_v0.24.md
@@ -14,6 +14,10 @@ Fields include:
 
 The module also defines the [`FromRequest`](../ohkami-0.24/ohkami/src/request/from_request.rs) trait which allows extracting custom types from a request. Handlers can accept any number of `FromRequest` values and the framework handles failures by returning an appropriate `Response`.
 
+Path parameters implement the separate `FromParam` trait.  Primitive types like
+`u32` and `String` are provided out of the box.  Compose them into structs with
+`#[derive(FromRequest)]` to conveniently capture multiple pieces of data.
+
 Example fang logging requests:
 
 ```rust,no_run
@@ -30,3 +34,4 @@ impl FangAction for Log {
 ```
 
 See the comments in `request/mod.rs` for additional details on payload limits and path parameter parsing.
+

--- a/docs/RESPONSE_v0.24.md
+++ b/docs/RESPONSE_v0.24.md
@@ -23,4 +23,10 @@ async fn handler() -> Response {
 Middleware can modify headers by calling `res.headers.set()` in their `back` method.
 When the `sse` feature is active a handler may return a streaming body and the framework handles chunked encoding automatically.
 
+For convenience the `typed::status` module defines constructors like
+`status::Created` and `status::NoContent` which return lightweight wrappers
+implementing `IntoResponse`.  Prefer these helpers when you simply need to send
+a standard status code.
+
 Review the documentation comments in `response/mod.rs` for details on WebSocket and SSE support.
+

--- a/docs/ROUTER_v0.24.md
+++ b/docs/ROUTER_v0.24.md
@@ -10,6 +10,11 @@ traverse the tree matching segments until reaching a handler.  Middleware (fangs
 registered at higher levels are collected along the way and wrap the handler in
 order.
 
+Each HTTP method has its own sub tree so a path can host different handlers for
+`GET`, `POST` and others.  Parameters are captured by name when traversing nodes
+and passed to handlers via `FromParam` implementations.  After building the tree
+`finalize()` flattens it into arrays for fast binary search at runtime.
+
 Understanding this structure helps when reading error messages about conflicting
 routes or parameter counts.  The public APIs hide these details but the source is
 useful if you need to debug complex route setups.

--- a/docs/SSE_v0.24.md
+++ b/docs/SSE_v0.24.md
@@ -17,4 +17,14 @@ async fn handler() -> DataStream {
 `DataStream::new` spawns an async producer with a queue.  The response is sent
 with `content-type: text/event-stream`.
 
+On the consumer side browsers can read these events using the JavaScript
+`EventSource` API.  Remember that Ohkami currently streams using HTTP/1.1
+chunked encoding, so a reverse proxy is required if you need HTTP/2 or HTTP/3
+support.
+
+Implement the `Data` trait for custom event types to control how items are
+encoded before being sent.  When the `openapi` feature is active the
+implementation also contributes schema information to the generated document.
+
+
 

--- a/docs/WS_v0.24.md
+++ b/docs/WS_v0.24.md
@@ -18,6 +18,22 @@ runs the provided async closure.
 
 On native runtimes connections time out after `OHKAMI_WEBSOCKET_TIMEOUT` seconds
 (default 3600).  The returned `Connection` can be split into read and write
-halves for concurrent tasks.
+halves for concurrent tasks:
+
+```rust,no_run
+let (mut read, mut write) = conn.split();
+loop {
+    if let Some(Message::Text(t)) = read.recv().await.expect("receive") {
+        println!("client -> {t}");
+        write.send(t).await.expect("send");
+    }
+}
+```
+
+`WebSocketContext` performs the WebSocket handshake and checks headers like
+`Sec-WebSocket-Version`. Use `upgrade_with` to supply a custom configuration from
+the underlying `mews` crate if you need control over frame sizes or ping
+timeouts.
+
 
 


### PR DESCRIPTION
## Summary
- document OpenAPI integration
- link new guide from docs index and update coverage roadmap
- expand SSE and WebSocket notes
- clarify router, header, format, macros, request and response guides

## Testing
- `cargo check` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_b_6854e8d4e2d8832e82fa5f4cdd34ad8a