### PR TITLE
Improve ohkami docs

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -6,7 +6,7 @@ It highlights which modules are documented and notes areas that still need work.
 ## Well Covered
 
 - `ohkami/src/ohkami` – explained throughout [CODING_GUIDE_v0.24](CODING_GUIDE_v0.24.md).
-- `ohkami/src/fang` – builtin middleware referenced in [CODING_GUIDE_v0.24](CODING_GUIDE_v0.24.md) and [PATTERNS_v0.24](PATTERNS_v0.24.md).
+- `ohkami/src/fang` – builtin middleware covered in [FANGS_v0.24](FANGS_v0.24.md), [CODING_GUIDE_v0.24](CODING_GUIDE_v0.24.md) and [PATTERNS_v0.24](PATTERNS_v0.24.md).
 - `ohkami/src/testing` – usage described in both guides above.
 - `ohkami/src/tls` – setup instructions in [STARTUP_GUIDE_v0.24](STARTUP_GUIDE_v0.24.md).
 - `ohkami/src/request` and `ohkami/src/response` – detailed in [REQUEST_v0.24](REQUEST_v0.24.md) and [RESPONSE_v0.24](RESPONSE_v0.24.md).
@@ -20,9 +20,7 @@ It highlights which modules are documented and notes areas that still need work.
 
 ## Partially Documented
 
-- `format`, `header`, `ws`, `sse` and the router internals now each have short
-  descriptions in dedicated Markdown files. More real‑world examples would still
-  be valuable.
+- `format`, `header`, `ws`, `sse` and the router internals now include example code in their docs. Further real-world guides are still welcome.
 
 
 Contributions are welcome!  Add notes or examples for any missing areas so both humans and LLMs can understand the framework more completely.

--- a/docs/FANGS_v0.24.md
+++ b/docs/FANGS_v0.24.md
@@ -1,0 +1,92 @@
+# Builtin Fangs
+
+Ohkami's middleware system revolves around **fangs**. A fang implements
+`FangAction` and can run code before and after a request handler.  The
+[`fang::builtin`](../ohkami-0.24/ohkami/src/fang/builtin) module ships
+several ready‑made fangs which cover common needs.
+
+## Context
+
+`Context::new(value)` stores arbitrary data for the lifetime of each request.
+Handlers can retrieve it by accepting `Context<'_, T>` as a parameter.
+This is useful for passing database pools or other shared resources.
+
+```rust,no_run
+use ohkami::fang::Context;
+
+fn app(pool: sqlx::PgPool) -> ohkami::Ohkami {
+    ohkami::Ohkami::new((
+        Context::new(pool),
+        "/users".GET(list_users),
+    ))
+}
+```
+
+## BasicAuth
+
+`BasicAuth { username, password }` guards routes using the HTTP
+`Authorization` header.  Multiple credentials can be provided via an array.
+
+```rust,no_run
+use ohkami::fang::BasicAuth;
+
+let secure = ohkami::Ohkami::new((
+    BasicAuth { username: "admin", password: "secret" },
+    "/".GET(private_handler),
+));
+```
+
+## JWT
+
+`JWT::<Payload>::new_256(secret)` verifies a JSON Web Token and stores the
+parsed payload in the request context.  Customize the retrieval of the token
+with `with_getter`.
+
+```rust,no_run
+use ohkami::fang::JWT;
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Claims { sub: String }
+
+let api = ohkami::Ohkami::new((
+    JWT::<Claims>::new_256("topsecret"),
+    "/profile".GET(profile),
+));
+```
+
+## CORS
+
+`CORS::new(origin)` configures `Access-Control-*` headers for cross origin
+requests.  Methods like `.AllowCredentials()` and `.AllowHeaders([...])`
+customize the response to pre‑flight and normal requests.
+
+```rust,no_run
+use ohkami::fang::CORS;
+
+let o = ohkami::Ohkami::new((
+    CORS::new("https://example.com").AllowCredentials(),
+    "/api".GET(handler),
+));
+```
+
+## Timeout
+
+`Timeout::by_secs(n)` aborts handlers that take longer than the specified
+duration on native runtimes.
+
+```rust,no_run
+use ohkami::fang::Timeout;
+
+Ohkami::new((Timeout::by_secs(10),
+    "/slow".GET(slow_handler),
+));
+```
+
+## Enamel
+
+`Enamel` adds a collection of security headers such as
+`Cross-Origin-Embedder-Policy` and `X-Frame-Options`. Use
+`Enamel::default()` and override fields as needed.
+
+These fangs can be combined when building an `Ohkami` instance.  Refer to the
+source files under `fang/builtin` for additional options and examples.

--- a/docs/FORMAT_v0.24.md
+++ b/docs/FORMAT_v0.24.md
@@ -40,3 +40,47 @@ traits in action.
 
 
 
+
+## Examples
+
+Parsing JSON from a request and responding with JSON:
+
+```rust,no_run
+use ohkami::prelude::*;
+use ohkami::typed::status;
+use ohkami::format::JSON;
+
+#[derive(Deserialize)]
+struct Create<'r> { name: &'r str }
+
+#[derive(Serialize)]
+struct User { name: String }
+
+async fn create_user(JSON(req): JSON<Create<'_>>)
+    -> status::Created<JSON<User>>
+{
+    status::Created(JSON(User { name: req.name.into() }))
+}
+```
+
+Handling file uploads with `Multipart`:
+
+```rust,no_run
+use ohkami::format::{Multipart, File};
+use ohkami::typed::status;
+
+#[derive(Deserialize)]
+struct FormData<'r> {
+    pics: Vec<File<'r>>,
+}
+
+async fn upload(Multipart(data): Multipart<FormData<'_>>)
+    -> status::NoContent
+{
+    println!("received {} files", data.pics.len());
+    status::NoContent
+}
+```
+
+These helpers keep parsing logic out of your handlers while remaining
+fully type‑checked.

--- a/docs/HEADERS_v0.24.md
+++ b/docs/HEADERS_v0.24.md
@@ -42,3 +42,26 @@ incoming requests.
 
 
 
+
+### Example
+
+Using `AcceptEncoding` to choose a compression scheme:
+
+```rust
+use ohkami::header::{AcceptEncoding, CompressionEncoding};
+
+if let Some(ae) = req.headers.AcceptEncoding() {
+    if ae.preferred() == Some(CompressionEncoding::Gzip) {
+        res.headers.set().ContentEncoding("gzip");
+    }
+}
+```
+
+Generating an `ETag` for caching:
+
+```rust
+use ohkami::header::ETag;
+
+let etag = ETag::weak("v1".into());
+res.headers.set().ETag(etag.clone());
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Use these guides when exploring version **0.24**.
 - [RUNTIME_ADAPTERS_v0.24.md](RUNTIME_ADAPTERS_v0.24.md) — deploying to Workers or Lambda.
 - [UTILS_v0.24.md](UTILS_v0.24.md) — helper functions and utility crate.
 - [MACROS_v0.24.md](MACROS_v0.24.md) — derive and attribute macros.
+- [FANGS_v0.24.md](FANGS_v0.24.md) — overview of builtin middleware.
 - [FORMAT_v0.24.md](FORMAT_v0.24.md) — request/response body helpers.
 - [HEADERS_v0.24.md](HEADERS_v0.24.md) — common header utilities.
 - [REQUEST_v0.24.md](REQUEST_v0.24.md) — request structure and extraction.

--- a/docs/ROUTER_v0.24.md
+++ b/docs/ROUTER_v0.24.md
@@ -20,3 +20,26 @@ routes or parameter counts.  The public APIs hide these details but the source i
 useful if you need to debug complex route setups.
 
 
+
+Example tree for nested routes:
+
+```rust,no_run
+use ohkami::prelude::*;
+
+async fn get_user(id: u32) -> String { format!("user {id}") }
+async fn create_user() -> &'static str { "created" }
+
+#[tokio::main]
+async fn main() {
+    let api = Ohkami::new((
+        "/users".GET(|| async {"list"}).POST(create_user),
+        "/users/:id".GET(get_user),
+    ));
+
+    Ohkami::new(("/api".By(api))).howl("localhost:5000").await;
+}
+```
+
+This builds a router with `/api/users` and `/api/users/:id` nodes containing
+handlers for `GET` and `POST` methods. The nested structure mirrors the path
+segments and allows middleware to be attached at any level.

--- a/docs/SSE_v0.24.md
+++ b/docs/SSE_v0.24.md
@@ -28,3 +28,25 @@ implementation also contributes schema information to the generated document.
 
 
 
+
+Example server using `tokio` runtime:
+
+```rust,no_run
+use ohkami::prelude::*;
+use ohkami::sse::DataStream;
+use tokio::time::{sleep, Duration};
+
+async fn stream() -> DataStream {
+    DataStream::new(|mut s| async move {
+        for i in 1..=3 {
+            sleep(Duration::from_secs(1)).await;
+            s.send(format!("tick {i}"));
+        }
+    })
+}
+
+#[tokio::main]
+async fn main() {
+    Ohkami::new(("/events".GET(stream))).howl("localhost:3030").await;
+}
+```

--- a/docs/WS_v0.24.md
+++ b/docs/WS_v0.24.md
@@ -37,3 +37,25 @@ timeouts.
 
 
 
+
+Simple echo server:
+
+```rust,no_run
+use ohkami::prelude::*;
+use ohkami::ws::{WebSocketContext, WebSocket, Message};
+
+async fn echo(ctx: WebSocketContext<'_>) -> WebSocket {
+    ctx.upgrade(|mut conn| async move {
+        while let Some(msg) = conn.recv().await.expect("recv") {
+            if let Message::Text(t) = msg {
+                conn.send(t).await.expect("send");
+            }
+        }
+    })
+}
+
+#[tokio::main]
+async fn main() {
+    Ohkami::new(("/ws".GET(echo))).howl("localhost:4040").await;
+}
+```


### PR DESCRIPTION
## Summary
- document builtin middleware in new `FANGS_v0.24.md`
- add examples for request/response formats
- show header helpers in action
- expand SSE, WebSocket, and router docs with runnable snippets
- link new docs from README and update roadmap

## Testing
- `cargo metadata --no-deps --format-version 1`

------
https://chatgpt.com/codex/tasks/task_b_6854ed81ed24832e99313c5c75105cf4