### PR TITLE
Improve docs coverage

### DIFF
--- a/docs/DIR_v0.24.md
+++ b/docs/DIR_v0.24.md
@@ -1,0 +1,49 @@
+# Static Directory Serving
+
+Ohkami ships with a built-in `Dir` fang for serving files from a directory on native runtimes. It lives in [`ohkami/src/ohkami/dir.rs`](../ohkami-0.24/ohkami/src/ohkami/dir.rs) and is enabled automatically when you use the `rt_*` features.
+
+`Dir` mounts a folder at a path and responds with files beneath that folder. It automatically sets `Content-Type`, `ETag` and `Last-Modified` headers and understands pre-compressed `.gz` and `.br` versions of files.
+
+## Basic Usage
+
+```rust,no_run
+use ohkami::prelude::*;
+
+#[tokio::main]
+async fn main() {
+    Ohkami::new((
+        "/".Dir("./public"),
+    )).howl("0.0.0.0:3030").await;
+}
+```
+
+## Options
+
+`Dir` exposes a few builder methods:
+
+- `.serve_dotfiles(bool)` – allow files starting with a dot (`.`). Defaults to `false`.
+- `.omit_extensions(&["html"])` – hide specific extensions so requests for `/index` serve `index.html`.
+- `.etag(fn(&File) -> String)` – supply a custom function to generate an `ETag` value.
+
+Pre-compressed files with extensions like `.gz` or `.br` are preferred when the client sends an `Accept-Encoding` header. If none of the prepared encodings are accepted and the client forbids `identity`, the handler returns **406 Not Acceptable**.
+
+Caching headers are respected: matching `If-None-Match` or `If-Modified-Since` results in **304 Not Modified**.
+
+`Dir` only works on native runtimes because Workers cannot access the local filesystem. When targeting Cloudflare Workers consider using Wrangler's `asset` feature instead.
+
+## Example with Options
+
+```rust,no_run
+use ohkami::prelude::*;
+
+#[tokio::main]
+async fn main() {
+    Ohkami::new((
+        "/".Dir("./public")
+            .omit_extensions(&["html"])
+            .serve_dotfiles(true),
+    )).howl("0.0.0.0:3000").await;
+}
+```
+
+This serves `index.html` at `/` and `/about.html` at `/about`. Dotfiles under `./public` are accessible.

--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -11,6 +11,7 @@ It highlights which modules are documented and notes areas that still need work.
 - `ohkami/src/tls` – setup instructions in [STARTUP_GUIDE_v0.24](STARTUP_GUIDE_v0.24.md).
 - `ohkami/src/request` and `ohkami/src/response` – detailed in [REQUEST_v0.24](REQUEST_v0.24.md) and [RESPONSE_v0.24](RESPONSE_v0.24.md).
 - `ohkami/src/typed` – explained in [TYPED_v0.24](TYPED_v0.24.md).
+- `ohkami/src/ohkami/dir` – static file serving in [DIR_v0.24](DIR_v0.24.md).
 
 - `ohkami/src/session` – lifecycle explained in [SESSION_v0.24](SESSION_v0.24.md).
 - Cloud runtime adapters (`x_worker`, `x_lambda`) documented in [RUNTIME_ADAPTERS_v0.24](RUNTIME_ADAPTERS_v0.24.md).
@@ -20,7 +21,7 @@ It highlights which modules are documented and notes areas that still need work.
 
 ## Partially Documented
 
-- `format`, `header`, `ws`, `sse` and the router internals now include example code in their docs. Further real-world guides are still welcome.
+- `format`, `header`, `ws`, `sse` and the router internals now include example code in their docs. Further real-world guides are still welcome. `Dir` was recently documented but additional recipes are encouraged.
 
 
 Contributions are welcome!  Add notes or examples for any missing areas so both humans and LLMs can understand the framework more completely.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ Use these guides when exploring version **0.24**.
 - [FANGS_v0.24.md](FANGS_v0.24.md) — overview of builtin middleware.
 - [FORMAT_v0.24.md](FORMAT_v0.24.md) — request/response body helpers.
 - [HEADERS_v0.24.md](HEADERS_v0.24.md) — common header utilities.
+- [DIR_v0.24.md](DIR_v0.24.md) — serving static files from a directory.
 - [REQUEST_v0.24.md](REQUEST_v0.24.md) — request structure and extraction.
 - [RESPONSE_v0.24.md](RESPONSE_v0.24.md) — building responses.
 - [TYPED_v0.24.md](TYPED_v0.24.md) — typed statuses and headers.


### PR DESCRIPTION
## Summary
- document built-in Dir fang for serving static files
- reference new guide from docs README
- update roadmap with Dir coverage

## Testing
- `cargo check` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_b_6854f980f840832eb50aab8730205005