### PR TITLE
Improve Ohkami docs

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -11,9 +11,12 @@ It highlights which modules are documented and notes areas that still need work.
 - `ohkami/src/tls` – setup instructions in [STARTUP_GUIDE_v0.24](STARTUP_GUIDE_v0.24.md).
 - `ohkami/src/request` and `ohkami/src/response` – detailed in [REQUEST_v0.24](REQUEST_v0.24.md) and [RESPONSE_v0.24](RESPONSE_v0.24.md).
 - `ohkami/src/typed` – explained in [TYPED_v0.24](TYPED_v0.24.md).
+- `ohkami/src/lib.rs` – crate root documented in the main README.
 - `ohkami/src/ohkami/dir` – static file serving in [DIR_v0.24](DIR_v0.24.md).
 - `ohkami/src/config` – environment variables documented in
   [CONFIGURATION_v0.24](CONFIGURATION_v0.24.md).
+- `ohkami/src/router` – tree structure and lookup process described in
+  [ROUTER_v0.24](ROUTER_v0.24.md).
 
 - `ohkami/src/session` – lifecycle explained in [SESSION_v0.24](SESSION_v0.24.md).
 - Cloud runtime adapters (`x_worker`, `x_lambda`) documented in [RUNTIME_ADAPTERS_v0.24](RUNTIME_ADAPTERS_v0.24.md).
@@ -25,7 +28,7 @@ It highlights which modules are documented and notes areas that still need work.
 
 ## Partially Documented
 
-- `format`, `header`, `ws`, `sse` and the router internals now include example code in their docs. Further real-world guides are still welcome. `Dir` was recently documented but additional recipes are encouraged.
+- `format`, `header`, `ws`, `sse` and portions of the router internals now include example code in their docs. Further real-world guides are still welcome. `Dir` was recently documented but additional recipes are encouraged.
 
 
 Contributions are welcome!  Add notes or examples for any missing areas so both humans and LLMs can understand the framework more completely.

--- a/docs/HEADERS_v0.24.md
+++ b/docs/HEADERS_v0.24.md
@@ -14,6 +14,9 @@ res.headers.set().Server(append("ohkami"));
 
 Multiple calls join the values with commas according to the HTTP spec.
 
+The same helper can be used with typed headers such as
+`ResponseHeaders::Server` to avoid string concatenation by hand.
+
 ## Cookie Builder
 
 `SetCookie` exposes a builder style API for generating `Set-Cookie` headers.
@@ -28,12 +31,16 @@ res.headers.set().SetCookie("id", "42", |c| c.Path("/").SameSiteLax());
 
 `ETag` parses strong and weak entity tags.  Use `ETag::parse` or the iterator
 helpers to process conditional request headers.
+It also implements `Display` so headers can be generated with
+`res.headers.set().ETag(etag.clone());`.
 
 ## Content Encoding
 
 `Encoding` and `CompressionEncoding` represent compression algorithms. The
 `AcceptEncoding` struct sorts algorithms by quality values (`QValue`) so you can
 negotiate compressed responses.
+The helper `QValue::parse` converts a quality string like `"0.8"` into a sortable
+floating point representation.
 
 Typed helpers exist for many common headers.  For example `ResponseHeaders` has
 methods like `ContentType` and `CacheControl` which accept strongly typed

--- a/docs/SESSION_v0.24.md
+++ b/docs/SESSION_v0.24.md
@@ -11,4 +11,22 @@ Key behaviors:
 - Logs connection errors and broken pipes with the utility macros from [`util`](../ohkami-0.24/ohkami/src/util.rs).
 - When upgraded to a WebSocket, delegates to `ws::WebSocket` with its own timeout (`OHKAMI_WEBSOCKET_TIMEOUT`).
 
+## Request/Response Loop
+
+`Session::manage` drives the lifetime of each TCP connection. It repeatedly
+parses a [`Request`](../ohkami-0.24/ohkami/src/request/mod.rs), routes it to the
+handler, sends the resulting [`Response`](../ohkami-0.24/ohkami/src/response/mod.rs)
+and continues until the client closes the socket. If the request sets
+`Connection: close` the loop exits after that response.
+
+The keep‑alive timer is reset on every successful read. When the timer elapses
+`manage` stops reading and the connection is dropped. Response sending uses
+`send()` which returns an `Upgrade` enum. If the handler initiated a WebSocket
+upgrade, `Session` switches over to the WebSocket manager which applies its own
+timeout.
+
+Errors while writing to the socket are printed via `WARNING!` or `ERROR!` and
+terminate the session. This helps surface issues such as broken pipes while not
+crashing the server process.
+
 The session module is internal but understanding it helps when customizing runtimes or debugging low‑level behavior.

--- a/docs/UTILS_v0.24.md
+++ b/docs/UTILS_v0.24.md
@@ -4,8 +4,11 @@ Several small helpers live under [`ohkami/src/util.rs`](../ohkami-0.24/ohkami/sr
 
 ## Logging Macros
 
-- `INFO!`, `WARNING!`, `ERROR!` and `DEBUG!` print messages consistently whether running natively or in Cloudflare Workers.
-- `push_unchecked!` quickly appends bytes onto a `Vec<u8>`.
+- `INFO!`, `WARNING!`, `ERROR!` and `DEBUG!` print messages consistently whether
+  running natively or in Cloudflare Workers. Each macro forwards to `eprintln!`
+  or `worker::console_*` as appropriate.
+- `push_unchecked!` quickly appends bytes onto a `Vec<u8>` without reallocating
+  when the capacity is sufficient.
 
 ## Data Utilities
 
@@ -13,6 +16,8 @@ Several small helpers live under [`ohkami/src/util.rs`](../ohkami-0.24/ohkami/sr
 - `iter_cookies` parses a raw `Cookie` header into `(name, value)` pairs.
 - `unix_timestamp` returns the current Unix time and works in both native and worker environments.
 - `timeout_in` wraps a future with a timeout when using native runtimes.
+- `percent_encode`, `percent_decode` and `percent_decode_utf8` provide basic URL
+  encoding helpers used throughout the framework.
 
 ## ohkami_lib Crate
 


### PR DESCRIPTION
## Summary
- extend `SESSION_v0.24` with details on the request/response loop
- clarify logging macros and utilities in `UTILS_v0.24`
- add more examples in `HEADERS_v0.24`
- expand roadmap with router coverage and other modules

## Testing
- `cargo --version`

------
https://chatgpt.com/codex/tasks/task_b_685575bea2b4832ea70ec0a43a9f212e