### PR TITLE
Expand typed and header docs

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -25,6 +25,7 @@ It highlights which modules are documented and notes areas that still need work.
 - `ohkami_openapi` documented in [OPENAPI_v0.24](OPENAPI_v0.24.md).
 - Dependency injection and typed error patterns now covered in
   [PATTERNS_v0.24](PATTERNS_v0.24.md).
+- Example projects under `samples/` summarized in [SAMPLES_v0.24](SAMPLES_v0.24.md).
 
 ## Partially Documented
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,3 +30,4 @@ Use these guides when exploring version **0.24**.
 - [DOCS_ROADMAP.md](DOCS_ROADMAP.md) — what parts of the source have been documented so far.
 - [FEATURE_REQUESTS.md](FEATURE_REQUESTS.md) — ideas for future improvements.
 - [examples/](examples/README.md) — documentation for the example projects.
+- [SAMPLES_v0.24.md](SAMPLES_v0.24.md) — overview of the larger sample projects.

--- a/docs/SAMPLES_v0.24.md
+++ b/docs/SAMPLES_v0.24.md
@@ -1,0 +1,15 @@
+# Sample Projects
+
+The `samples/` directory contains more complete applications built with Ohkami **v0.24**. They demonstrate advanced features beyond the small
+[examples](examples/README.md) folder.
+
+- **petstore** – showcases the `openapi` integration by implementing a minimal Petstore API. Generated OpenAPI JSON and a simple JS client are included.
+- **realworld** – partial implementation of the RealWorld spec with JWT authentication and database usage.
+- **streaming** – demonstrates streaming responses using Server-Sent Events and WebSocket helpers.
+- **worker-with-openapi** – template for deploying to Cloudflare Workers with automatic OpenAPI generation.
+- **worker-durable-websocket** – Workers sample using Durable Objects to manage WebSocket sessions.
+- **worker-bindings** / **worker-bindings-jsonc** – show the `#[bindings]` macro and JSONC configuration.
+- **openapi-tags**, **openapi-schema-enums**, **openapi-schema-from-into** – short programs illustrating OpenAPI tagging and schema derivations.
+- **issue_459** – minimal reproduction of a GitHub issue used for regression tests.
+
+Each project has its own `Cargo.toml` and can be run directly. Browse the source under [`ohkami-0.24/samples`](../ohkami-0.24/samples) for details.

--- a/docs/TYPED_v0.24.md
+++ b/docs/TYPED_v0.24.md
@@ -19,3 +19,44 @@ async fn created() -> status::Created<&'static str> {
 `typed::header` declares the `FromHeader` trait used to parse custom types from request headers. When the `openapi` feature is enabled these types also implement `Schema` for documentation generation.
 
 Implement `FromHeader` for your own structs to automatically fail the request when parsing fails.
+
+Typed status wrappers automatically set `Content-Type` and `Content-Length` based on the body. Use `.with_headers` to attach additional headers:
+
+```rust,no_run
+use ohkami::typed::{status, header};
+
+async fn created_user(JSON(user): JSON<User>)
+    -> status::Created<JSON<User>>
+{
+    status::Created(JSON(user))
+        .with_headers(|h| h.Location("/users/42"))
+}
+```
+
+### Custom Header Types
+
+`typed::header` exposes structs like `Authorization`, `ContentType` and `Cookie`. They implement `FromRequest` so handlers simply name the header they need. Custom types implementing [`FromHeader`](../ohkami-0.24/ohkami/src/typed/header.rs) can be used with these wrappers.
+
+```rust,no_run
+use ohkami::prelude::*;
+use ohkami::typed::{status, header};
+
+struct BearerToken(String);
+impl<'r> header::FromHeader<'r> for BearerToken {
+    type Error = status::Unauthorized<&'static str>;
+    fn from_header(raw: &'r str) -> Result<Self, Self::Error> {
+        raw.strip_prefix("Bearer ")
+            .map(|t| Self(t.to_owned()))
+            .ok_or(status::Unauthorized("invalid token"))
+    }
+}
+
+async fn api(header::Authorization(BearerToken(token)): header::Authorization<BearerToken>)
+    -> &'static str
+{
+    println!("token: {token}");
+    "ok"
+}
+```
+
+The `Cookie` wrapper works similarly but parses the header into a struct that implements `Deserialize`. See the source for more details.


### PR DESCRIPTION
## Summary
- clarify typed statuses and header extraction patterns
- add notes on custom typed headers
- document full sample projects
- link new samples guide from README and roadmap

## Testing
- `cargo test --manifest-path ohkami-0.24/Cargo.toml` *(fails: download of config.json failed)*

------
https://chatgpt.com/codex/tasks/task_b_6855795e0ca4832e91ff7f512377b81b