### PR TITLE
Improve docs with error handling guide

### DIFF
--- a/docs/CONFIGURATION_v0.24.md
+++ b/docs/CONFIGURATION_v0.24.md
@@ -10,4 +10,6 @@ These options are read at startup and apply to all servers.
 - `OHKAMI_WEBSOCKET_TIMEOUT` – WebSocket session timeout in seconds.
   Defaults to **3600** seconds (1 hour) and only applies with the `ws` feature.
 
-Increase these values if clients send large headers or WebSocket connections should persist longer.
+Values are parsed once using `LazyLock`. Invalid or missing variables fall back
+to the defaults above. Increase these numbers if clients send large headers or
+WebSocket connections should persist longer.

--- a/docs/ERROR_HANDLING_v0.24.md
+++ b/docs/ERROR_HANDLING_v0.24.md
@@ -1,0 +1,62 @@
+# Error Handling
+
+Ohkami handlers can return `Result<T, E>` where `E` implements `IntoResponse`.
+This allows custom error types to map directly to HTTP responses.  The
+`response` module provides an `IntoResponse` trait used throughout the
+framework.
+
+## Defining Error Types
+
+Create an enum of possible failures and implement `IntoResponse`.  Use typed
+status helpers from `typed::status` to keep responses uniform.
+
+```rust
+use ohkami::{Response, IntoResponse};
+use ohkami::typed::status;
+
+enum MyError {
+    Db(sqlx::Error),
+    NotFound,
+}
+
+impl IntoResponse for MyError {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Db(_) => status::InternalServerError(()).into_response(),
+            Self::NotFound => status::NotFound(()).into_response(),
+        }
+    }
+}
+```
+
+Handlers simply return `Result<T, MyError>` and the framework converts the
+result automatically:
+
+```rust,no_run
+async fn fetch_user(id: u32) -> Result<String, MyError> {
+    if id == 0 { return Err(MyError::NotFound); }
+    Ok("user".into())
+}
+```
+
+## Using `thiserror`
+
+The [`thiserror`](https://crates.io/crates/thiserror) crate can reduce
+boilerplate when mapping errors.  Derive `Error` and use `#[from]` to convert
+inner types:
+
+```rust,ignore
+#[derive(thiserror::Error, Debug)]
+enum MyError {
+    #[error("db error: {0}")]
+    Db(#[from] sqlx::Error),
+}
+```
+
+## Logging Failures
+
+Fangs or handlers may log errors using the macros from
+[`util.rs`](../ohkami-0.24/ohkami/src/util.rs) such as `ERROR!` or `WARNING!`.
+
+Error handling keeps your API consistent and makes unit tests straightforward
+because every failure path yields a deterministic `Response`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Use these guides when exploring version **0.24**.
 - [DIR_v0.24.md](DIR_v0.24.md) — serving static files from a directory.
 - [REQUEST_v0.24.md](REQUEST_v0.24.md) — request structure and extraction.
 - [RESPONSE_v0.24.md](RESPONSE_v0.24.md) — building responses.
+- [ERROR_HANDLING_v0.24.md](ERROR_HANDLING_v0.24.md) — converting errors to responses.
 - [TYPED_v0.24.md](TYPED_v0.24.md) — typed statuses and headers.
 - [OPENAPI_v0.24.md](OPENAPI_v0.24.md) — generating OpenAPI documentation.
 - [TLS_v0.24.md](TLS_v0.24.md) — HTTPS support.

--- a/docs/ROUTER_v0.24.md
+++ b/docs/ROUTER_v0.24.md
@@ -19,6 +19,13 @@ Understanding this structure helps when reading error messages about conflicting
 routes or parameter counts.  The public APIs hide these details but the source is
 useful if you need to debug complex route setups.
 
+## Path Validation
+
+Route segments are validated when building the router. Segment names may only
+contain ASCII letters, digits and `-._~`. Parameters start with a leading colon
+(`:`) and follow the same character rules. The implementation rejects empty or
+malformed segments early so typos are caught at startup.
+
 
 
 Example tree for nested routes:


### PR DESCRIPTION
## Summary
- add new ERROR_HANDLING_v0.24 guide
- document path validation rules in router notes
- clarify config variable parsing
- link the new guide from docs README

## Testing
- `cargo check -p ohkami --quiet` *(fails: internet access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_6855f9af9080832eba3e845b0c505b67