### PR TITLE
Add docs for features, tasks and benches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Doc Contribution Guide
+
+This repository focuses on documentation for Ohkami v0.24.
+
+* Place all Markdown guides under the `docs/` directory. Use the suffix `_v0.24` for
+  files that specifically cover the 0.24 code.
+* Keep lines under 100 characters for readability.
+* Link to source files using relative paths to the `ohkami-0.24` directory.
+* Whenever a new doc is added or changed, update `docs/README.md` so readers can find it.
+* Update `docs/DOCS_ROADMAP.md` with notes about which modules are documented and any remaining gaps.
+* Code changes should compile via `cargo check` under `ohkami-0.24` when applicable, but
+  documentation-only changes do not require compilation.

--- a/docs/BENCHES_v0.24.md
+++ b/docs/BENCHES_v0.24.md
@@ -1,0 +1,15 @@
+# Benchmarks
+
+The repository includes micro benchmarks under `ohkami-0.24/benches`. These use
+Rust's built‑in `criterion` and nightly `test` harnesses to measure
+performance of internal utilities like header parsing.
+
+Run benchmarks from the workspace root with:
+
+```sh
+cargo bench --workspace
+```
+
+The `benches_rt` directory contains experiments comparing runtimes. Each
+subfolder (`tokio`, `smol`, `nio`, `glommio`) is a small binary crate that can be
+executed with `cargo run --release` to gauge throughput on your machine.

--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -26,10 +26,17 @@ It highlights which modules are documented and notes areas that still need work.
 - Dependency injection and typed error patterns now covered in
   [PATTERNS_v0.24](PATTERNS_v0.24.md).
 - Example projects under `samples/` summarized in [SAMPLES_v0.24](SAMPLES_v0.24.md).
+- `Taskfile.yaml` commands described in [TASKS_v0.24](TASKS_v0.24.md).
+- Benchmark crates explained in [BENCHES_v0.24](BENCHES_v0.24.md).
+- Cargo feature flags listed in [FEATURE_FLAGS_v0.24](FEATURE_FLAGS_v0.24.md).
 
 ## Partially Documented
 
 - `format`, `header`, `ws`, `sse` and portions of the router internals now include example code in their docs. Further real-world guides are still welcome. `Dir` was recently documented but additional recipes are encouraged.
 
+Additional gaps:
+
+- Detailed benchmarking results and tuning tips are not yet covered.
+- More real‑world taskfile usage examples would help new contributors.
 
 Contributions are welcome!  Add notes or examples for any missing areas so both humans and LLMs can understand the framework more completely.

--- a/docs/FEATURE_FLAGS_v0.24.md
+++ b/docs/FEATURE_FLAGS_v0.24.md
@@ -1,0 +1,24 @@
+# Feature Flags
+
+Ohkami exposes several optional Cargo features. These control which runtimes and
+protocol helpers are compiled. Enable the features that match your deployment
+environment.
+
+## Runtime selection
+
+- `rt_tokio`, `rt_smol`, `rt_nio`, `rt_glommio` – run on a native async runtime.
+- `rt_worker` – compile to WebAssembly for Cloudflare Workers.
+- `rt_lambda` – experimental support for AWS Lambda.
+
+Only one runtime should be selected at a time.
+
+## Protocols
+
+- `sse` – enable Server‑Sent Events via `DataStream`.
+- `ws` – enable WebSocket helpers.
+- `openapi` – generate an `openapi.json` from route definitions.
+- `tls` – HTTPS support using `rustls`.
+- `nightly` – nightly only features and optimizations.
+
+See the [README](../ohkami-0.24/README.md#feature-flags) for a detailed
+walkthrough of each flag and example usage.

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,9 @@ Use these guides when exploring version **0.24**.
 - [WS_v0.24.md](WS_v0.24.md) — upgrading connections to WebSockets.
 - [SSE_v0.24.md](SSE_v0.24.md) — streaming Server‑Sent Events.
 - [ROUTER_v0.24.md](ROUTER_v0.24.md) — how routes are organized internally.
+- [FEATURE_FLAGS_v0.24.md](FEATURE_FLAGS_v0.24.md) — optional Cargo features.
+- [TASKS_v0.24.md](TASKS_v0.24.md) — common `task` commands.
+- [BENCHES_v0.24.md](BENCHES_v0.24.md) — running performance benchmarks.
 
 - [CONFIGURATION_v0.24.md](CONFIGURATION_v0.24.md) — environment variables and runtime tuning.
 - [DOCS_ROADMAP.md](DOCS_ROADMAP.md) — what parts of the source have been documented so far.

--- a/docs/TASKS_v0.24.md
+++ b/docs/TASKS_v0.24.md
@@ -1,0 +1,21 @@
+# Taskfile Commands
+
+Development chores are automated via `Taskfile.yaml` at the workspace root. The
+[YAML](../ohkami-0.24/Taskfile.yaml) defines commands run by the `task` CLI
+(https://taskfile.dev).
+
+Common tasks include:
+
+- `task check` – run `cargo check` for all crates.
+- `task test` – execute the test suite.
+- `task fmt` – format the code using `cargo fmt`.
+- `task ci` – shortcut that runs formatting, checks and tests; used by CI.
+
+Install the `task` binary from <https://taskfile.dev> then run e.g.:
+
+```sh
+# format and check code
+task ci
+```
+
+These tasks are optional but mirror the commands used in CI pipelines.


### PR DESCRIPTION
## Summary
- document cargo features, Taskfile commands and benchmark folders
- list the new docs in README and update roadmap
- add AGENTS guide for documentation contributions

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6856100e4ea4832e918ca8e1a73c6857