### PR TITLE
Update docs with benchmark tuning

### DIFF
--- a/docs/BENCHES_v0.24.md
+++ b/docs/BENCHES_v0.24.md
@@ -13,3 +13,25 @@ cargo bench --workspace
 The `benches_rt` directory contains experiments comparing runtimes. Each
 subfolder (`tokio`, `smol`, `nio`, `glommio`) is a small binary crate that can be
 executed with `cargo run --release` to gauge throughput on your machine.
+
+## Adjusting Criterion
+
+You can tweak the benchmark parameters by passing options after `--`.
+For example to increase the sample size and warm up longer:
+
+```sh
+cargo bench --bench headers -- --sample-size 100 --warm-up-time 2
+```
+
+Results are written to `target/criterion`. Open the HTML report in that
+directory to compare runs over time.
+
+### Runtime Examples
+
+The runtime comparison crates accept feature flags so you can test HTTPS or
+other integrations. To benchmark the Tokio version with TLS enabled:
+
+```sh
+cd ohkami-0.24/benches_rt/tokio
+cargo run --release --features tls
+```

--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -36,7 +36,8 @@ It highlights which modules are documented and notes areas that still need work.
 
 Additional gaps:
 
-- Detailed benchmarking results and tuning tips are not yet covered.
+- Benchmarking basics are documented but real performance numbers are still
+  missing.
 - More real‑world taskfile usage examples would help new contributors.
 
 Contributions are welcome!  Add notes or examples for any missing areas so both humans and LLMs can understand the framework more completely.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,7 @@
 # Ohkami v0.24 Documentation
 
-This directory collects learning material for the [Ohkami](https://github.com/ohkami-rs/ohkami) web framework.
+This directory collects learning material for the
+[Ohkami](https://github.com/ohkami-rs/ohkami) web framework.
 Use these guides when exploring version **0.24**.
 
 - [STARTUP_GUIDE_v0.24.md](STARTUP_GUIDE_v0.24.md) — installation and running your first server.
@@ -28,11 +29,11 @@ Use these guides when exploring version **0.24**.
 - [ROUTER_v0.24.md](ROUTER_v0.24.md) — how routes are organized internally.
 - [FEATURE_FLAGS_v0.24.md](FEATURE_FLAGS_v0.24.md) — optional Cargo features.
 - [TASKS_v0.24.md](TASKS_v0.24.md) — common `task` commands.
-- [BENCHES_v0.24.md](BENCHES_v0.24.md) — running performance benchmarks.
+- [BENCHES_v0.24.md](BENCHES_v0.24.md) — performance benchmarks and tuning tips.
 
 - [CONFIGURATION_v0.24.md](CONFIGURATION_v0.24.md) — environment variables and runtime tuning.
 - [DOCS_ROADMAP.md](DOCS_ROADMAP.md) — what parts of the source have been documented so far.
 - [FEATURE_REQUESTS.md](FEATURE_REQUESTS.md) — ideas for future improvements.
 - [examples/](examples/README.md) — documentation for the example projects.
 - [SAMPLES_v0.24.md](SAMPLES_v0.24.md) — overview of the larger sample projects.
-- [NOTES_FROM_SOURCE_v0.24.md](NOTES_FROM_SOURCE_v0.24.md) — summary of design cues directly from the source code.
+- [NOTES_FROM_SOURCE_v0.24.md](NOTES_FROM_SOURCE_v0.24.md) — design notes from the source.


### PR DESCRIPTION
## Summary
- expand `BENCHES_v0.24` with Criterion options and runtime example
- tighten wording in `docs/README.md`
- update `DOCS_ROADMAP.md` noting benchmark coverage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68561ab3c198832ea00334f06830e84e