### PR TITLE
Add documentation for prelude module

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -12,6 +12,7 @@ It highlights which modules are documented and notes areas that still need work.
 - `ohkami/src/request` and `ohkami/src/response` – detailed in [REQUEST_v0.24](REQUEST_v0.24.md) and [RESPONSE_v0.24](RESPONSE_v0.24.md).
 - `ohkami/src/typed` – explained in [TYPED_v0.24](TYPED_v0.24.md).
 - `ohkami/src/lib.rs` – crate root documented in the main README.
+- `ohkami/src/lib.rs::prelude` – imports covered in [PRELUDE_v0.24](PRELUDE_v0.24.md).
 - `ohkami/src/ohkami/dir` – static file serving in [DIR_v0.24](DIR_v0.24.md).
 - `ohkami/src/config` – environment variables documented in
   [CONFIGURATION_v0.24](CONFIGURATION_v0.24.md).

--- a/docs/PRELUDE_v0.24.md
+++ b/docs/PRELUDE_v0.24.md
@@ -1,0 +1,31 @@
+# Prelude Module
+
+The [`prelude`](../ohkami-0.24/ohkami/src/lib.rs) re-exports the most common
+traits and types so examples can simply `use ohkami::prelude::*`.
+This keeps boilerplate low when writing handlers.
+
+## What it Contains
+
+- `Request`, `Response`, `IntoResponse`, `Method` and `Status`
+- [`FangAction`](../ohkami-0.24/ohkami/src/util.rs) for middleware control
+- The `Serialize` and `Deserialize` derives from `ohkami_macros`
+- Format helpers like [`JSON`] and [`Query`](../ohkami-0.24/ohkami/src/format)
+- `Context` for fangs
+- `Route` and `Ohkami` when a runtime feature is active
+
+## Example
+
+```rust
+use ohkami::prelude::*;
+
+async fn hello() -> Response {
+    JSON("hi").into_response()
+}
+
+#[tokio::main]
+async fn main() {
+    Ohkami::new(("/".GET(hello))).howl("localhost:3000").await;
+}
+```
+
+The prelude is optional; you can import items individually if you prefer explicit paths.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Use these guides when exploring version **0.24**.
 - [STARTUP_GUIDE_v0.24.md](STARTUP_GUIDE_v0.24.md) — installation and running your first server.
 - [CODING_GUIDE_v0.24.md](CODING_GUIDE_v0.24.md) — walkthrough of common APIs and patterns.
 - [CODE_STYLE_v0.24.md](CODE_STYLE_v0.24.md) — conventions used throughout the code base.
+- [PRELUDE_v0.24.md](PRELUDE_v0.24.md) — common re‑exports used in examples.
 - [PATTERNS_v0.24.md](PATTERNS_v0.24.md) — useful idioms taken from the implementation.
 - [ARCHITECTURE_v0.24.md](ARCHITECTURE_v0.24.md) — overview of crate modules.
 - [SESSION_v0.24.md](SESSION_v0.24.md) — how connections are managed.


### PR DESCRIPTION
## Summary
- document the `ohkami::prelude` exports
- link new page from `README.md`
- note coverage in `DOCS_ROADMAP`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68561cf02508832eaea5814163583fff