### PR TITLE
Add environment setup guide

### DIFF
--- a/ENV_SETUP.md
+++ b/ENV_SETUP.md
@@ -1,0 +1,44 @@
+# Environment Setup Guide
+
+Follow these steps to build and run the Ohkami sources included in this repository.
+
+## Prerequisites
+
+- Install Rust via [rustup](https://rustup.rs) and make sure `cargo` is on your PATH.
+- Use a toolchain that supports the 2024 edition. A recent stable release is fine.
+- The optional [`task`](https://taskfile.dev) CLI provides shortcuts for common commands.
+
+## Initial build
+
+Run the build once so Cargo downloads all crates:
+
+```bash
+cd ohkami-0.24
+cargo build
+```
+
+This compiles every workspace crate and caches dependencies in `~/.cargo/`.
+
+## Development tasks
+
+Inside `ohkami-0.24` you can run:
+
+```bash
+# check all crates
+cargo check
+
+# run tests
+cargo test
+```
+
+If you installed `task`, the shortcut `task ci` formats, checks and tests the code.
+
+## Runtime configuration
+
+Three environment variables tweak server behavior when using native runtimes:
+
+- `OHKAMI_REQUEST_BUFSIZE` – request buffer size in bytes (default 2048).
+- `OHKAMI_KEEPALIVE_TIMEOUT` – keep‑alive timeout in seconds (default 30).
+- `OHKAMI_WEBSOCKET_TIMEOUT` – WebSocket timeout in seconds (default 3600).
+
+Increase these values if clients send large headers or hold WebSocket connections open.

--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -30,6 +30,7 @@ It highlights which modules are documented and notes areas that still need work.
 - `Taskfile.yaml` commands described in [TASKS_v0.24](TASKS_v0.24.md).
 - Benchmark crates explained in [BENCHES_v0.24](BENCHES_v0.24.md).
 - Cargo feature flags listed in [FEATURE_FLAGS_v0.24](FEATURE_FLAGS_v0.24.md).
+- Workspace setup documented in [../ENV_SETUP.md](../ENV_SETUP.md).
 
 ## Partially Documented
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,3 +38,4 @@ Use these guides when exploring version **0.24**.
 - [examples/](examples/README.md) — documentation for the example projects.
 - [SAMPLES_v0.24.md](SAMPLES_v0.24.md) — overview of the larger sample projects.
 - [NOTES_FROM_SOURCE_v0.24.md](NOTES_FROM_SOURCE_v0.24.md) — design notes from the source.
+- [../ENV_SETUP.md](../ENV_SETUP.md) — initializing the workspace environment.


### PR DESCRIPTION
## Summary
- document environment setup steps in a new `ENV_SETUP.md`
- link the guide from `docs/README.md`
- note the workspace setup in `docs/DOCS_ROADMAP.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685628578540832eaf48a6467337843c