### PR TITLE
Add benchmark file summary

### DIFF
--- a/docs/BENCHES_v0.24.md
+++ b/docs/BENCHES_v0.24.md
@@ -14,6 +14,22 @@ The `benches_rt` directory contains experiments comparing runtimes. Each
 subfolder (`tokio`, `smol`, `nio`, `glommio`) is a small binary crate that can be
 executed with `cargo run --release` to gauge throughput on your machine.
 
+### Bench Files
+
+Micro benchmarks under `benches/benches` cover:
+
+- `content.rs` — copy strategies for request bodies.
+- `imf_fixdate.rs` — formatting RFC 1123 dates.
+- `itoa.rs` — integer to ASCII conversions.
+- `request_headers.rs` — parsing incoming headers.
+
+Common helpers live in `benches/src`, such as the `header_map.rs` example map.
+
+Runtime benchmarks live in `benches_rt`:
+
+- `tokio`, `smol`, `nio` and `glommio` — minimal servers for each runtime.
+- `vs_actix-web` — reference implementation using Actix Web.
+
 ## Adjusting Criterion
 
 You can tweak the benchmark parameters by passing options after `--`.

--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -28,7 +28,8 @@ It highlights which modules are documented and notes areas that still need work.
   [PATTERNS_v0.24](PATTERNS_v0.24.md).
 - Example projects under `samples/` summarized in [SAMPLES_v0.24](SAMPLES_v0.24.md).
 - `Taskfile.yaml` commands described in [TASKS_v0.24](TASKS_v0.24.md).
-- Benchmark crates explained in [BENCHES_v0.24](BENCHES_v0.24.md).
+- Benchmark crates explained in [BENCHES_v0.24](BENCHES_v0.24.md), including lists
+  of micro benchmark modules and runtime comparison crates.
 - Cargo feature flags listed in [FEATURE_FLAGS_v0.24](FEATURE_FLAGS_v0.24.md).
 - Workspace setup documented in [../ENV_SETUP.md](../ENV_SETUP.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ Use these guides when exploring version **0.24**.
 - [ROUTER_v0.24.md](ROUTER_v0.24.md) — how routes are organized internally.
 - [FEATURE_FLAGS_v0.24.md](FEATURE_FLAGS_v0.24.md) — optional Cargo features.
 - [TASKS_v0.24.md](TASKS_v0.24.md) — common `task` commands.
-- [BENCHES_v0.24.md](BENCHES_v0.24.md) — performance benchmarks and tuning tips.
+- [BENCHES_v0.24.md](BENCHES_v0.24.md) — micro and runtime benchmarks with tuning tips.
 
 - [CONFIGURATION_v0.24.md](CONFIGURATION_v0.24.md) — environment variables and runtime tuning.
 - [DOCS_ROADMAP.md](DOCS_ROADMAP.md) — what parts of the source have been documented so far.


### PR DESCRIPTION
## Summary
- document micro benchmark modules and runtime crates
- describe the benchmark docs in README and roadmap

## Testing
- `grep -n '.\{101\}' -n docs/BENCHES_v0.24.md`
- `grep -n '.\{101\}' -n docs/README.md`
- `grep -n '.\{101\}' -n docs/DOCS_ROADMAP.md`


------
https://chatgpt.com/codex/tasks/task_b_685b548f2a48832e9f71fff0727c7517