### PR TITLE
Run ohkami-0.24 benches

### DIFF
--- a/errors.txt
+++ b/errors.txt
@@ -1,0 +1,11 @@
+Failed to run `cargo bench --workspace` within `ohkami-0.24`.
+The command attempted to update crates.io index but network access is disabled:
+
+warning: spurious network error (3 tries remaining): [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403)
+warning: spurious network error (2 tries remaining): [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403)
+warning: spurious network error (1 tries remaining): [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403)
+error: failed to get `base64` as a dependency of package `ohkami v0.24.0 (/workspace/ohkami-v0.23.5-to-0.24-migration-notes/ohkami-0.24/ohkami)`
+Caused by:
+  download of config.json failed
+  failed to download from `https://index.crates.io/config.json`
+  [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403)


### PR DESCRIPTION
## Summary
- attempted to run the `ohkami-0.24` benchmark suite
- wrote the failure message to `errors.txt`

## Testing
- `cargo bench --workspace` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_685b596362b4832e925a65f481887133