### PR TITLE
Add setup script and update error log

### DIFF
--- a/errors.txt
+++ b/errors.txt
@@ -1,11 +1,14 @@
-Failed to run `cargo bench --workspace` within `ohkami-0.24`.
-The command attempted to update crates.io index but network access is disabled:
-
+    Updating crates.io index
 warning: spurious network error (3 tries remaining): [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403)
 warning: spurious network error (2 tries remaining): [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403)
 warning: spurious network error (1 tries remaining): [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403)
 error: failed to get `base64` as a dependency of package `ohkami v0.24.0 (/workspace/ohkami-v0.23.5-to-0.24-migration-notes/ohkami-0.24/ohkami)`
+
 Caused by:
   download of config.json failed
+
+Caused by:
   failed to download from `https://index.crates.io/config.json`
+
+Caused by:
   [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403)

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Setup script to prepare dependencies for Ohkami benchmarks
+# This attempts to vendor the crates so cargo can run offline.
+
+set -euo pipefail
+
+# navigate to workspace root of the 0.24 code
+cd "$(dirname "$0")/ohkami-0.24"
+
+# vendor dependencies if not already vendored
+if [ ! -d vendor ]; then
+    echo "Vendor directory not found. Running cargo vendor..."
+    cargo vendor vendor > /tmp/vendor-config.toml
+    mkdir -p .cargo
+    cat /tmp/vendor-config.toml > .cargo/config.toml
+fi
+
+# fetch all dependencies (uses vendor if available)
+cargo fetch


### PR DESCRIPTION
## Summary
- attempt to run benchmarks; network blocked crates.io access
- record the failed benchmark output in `errors.txt`
- provide a `setup.sh` script that vendors dependencies and fetches them offline

## Testing
- `cargo bench --workspace` *(fails: CONNECT tunnel failed)*
- `cargo check --workspace` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_b_685b87d9079c832eaac90359e71c622a