### PR TITLE
Add TODO checklist for docs verification

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -45,5 +45,7 @@ Additional gaps:
 - Utility modules such as `ohkami_lib::stream`, `slice`, `time` and `num` are not
   yet covered in [UTILS_v0.24](UTILS_v0.24.md).
 - The AWS Lambda WebSocket adapter remains unfinished and lacks documentation.
+- Each guide should be audited for accuracy. See
+  [DOCS_TODO_v0.24.md](DOCS_TODO_v0.24.md) for the full checklist.
 
 Contributions are welcome!  Add notes or examples for any missing areas so both humans and LLMs can understand the framework more completely.

--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -1,0 +1,58 @@
+# Documentation Verification Tasks
+
+Below is a TODO list for auditing every Markdown file under the `docs/` directory.
+Each item should be checked off once the guide has been reviewed against the
+`ohkami-0.24` source and updated with any missing details or examples.
+
+## Guides
+
+- [ ] Review `ARCHITECTURE_v0.24.md`
+- [ ] Review `BENCHES_v0.24.md`
+- [ ] Review `CODE_STYLE_v0.24.md`
+- [ ] Review `CODING_GUIDE_v0.24.md`
+- [ ] Review `CONFIGURATION_v0.24.md`
+- [ ] Review `DIR_v0.24.md`
+- [ ] Review `DOCS_ROADMAP.md`
+- [ ] Review `DOCS_TODO_v0.24.md`
+- [ ] Review `ERROR_HANDLING_v0.24.md`
+- [ ] Review `FANGS_v0.24.md`
+- [ ] Review `FEATURE_FLAGS_v0.24.md`
+- [ ] Review `FEATURE_REQUESTS.md`
+- [ ] Review `FORMAT_v0.24.md`
+- [ ] Review `HEADERS_v0.24.md`
+- [ ] Review `MACROS_v0.24.md`
+- [ ] Review `NOTES_FROM_SOURCE_v0.24.md`
+- [ ] Review `OPENAPI_v0.24.md`
+- [ ] Review `PATTERNS_v0.24.md`
+- [ ] Review `PRELUDE_v0.24.md`
+- [ ] Review `README.md`
+- [ ] Review `REQUEST_v0.24.md`
+- [ ] Review `RESPONSE_v0.24.md`
+- [ ] Review `ROUTER_v0.24.md`
+- [ ] Review `RUNTIME_ADAPTERS_v0.24.md`
+- [ ] Review `SAMPLES_v0.24.md`
+- [ ] Review `SESSION_v0.24.md`
+- [ ] Review `SSE_v0.24.md`
+- [ ] Review `STARTUP_GUIDE_v0.24.md`
+- [ ] Review `TASKS_v0.24.md`
+- [ ] Review `TESTING_v0.24.md`
+- [ ] Review `TLS_v0.24.md`
+- [ ] Review `TYPED_v0.24.md`
+- [ ] Review `UTILS_v0.24.md`
+- [ ] Review `WS_v0.24.md`
+
+## Examples
+- [ ] Review `examples/README.md`
+- [ ] Review `examples/basic_auth.md`
+- [ ] Review `examples/chatgpt.md`
+- [ ] Review `examples/derive_from_request.md`
+- [ ] Review `examples/form.md`
+- [ ] Review `examples/hello.md`
+- [ ] Review `examples/html_layout.md`
+- [ ] Review `examples/json_response.md`
+- [ ] Review `examples/jwt.md`
+- [ ] Review `examples/multiple-single-threads.md`
+- [ ] Review `examples/quick_start.md`
+- [ ] Review `examples/sse.md`
+- [ ] Review `examples/static_files.md`
+- [ ] Review `examples/websocket.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ Use these guides when exploring version **0.24**.
 
 - [CONFIGURATION_v0.24.md](CONFIGURATION_v0.24.md) — environment variables and runtime tuning.
 - [DOCS_ROADMAP.md](DOCS_ROADMAP.md) — what parts of the source have been documented so far.
+- [DOCS_TODO_v0.24.md](DOCS_TODO_v0.24.md) — checklist for verifying each guide.
 - [FEATURE_REQUESTS.md](FEATURE_REQUESTS.md) — ideas for future improvements.
 - [examples/](examples/README.md) — documentation for the example projects.
 - [SAMPLES_v0.24.md](SAMPLES_v0.24.md) — overview of the larger sample projects.


### PR DESCRIPTION
## Summary
- add `DOCS_TODO_v0.24.md` with tasks for each documentation file
- reference the checklist from `docs/README.md`
- note checklist in `DOCS_ROADMAP.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685d8e04e948832ea413c7d71b7c650f