### PR TITLE
Update configuration docs

### DIFF
--- a/docs/CONFIGURATION_v0.24.md
+++ b/docs/CONFIGURATION_v0.24.md
@@ -1,6 +1,7 @@
 # Runtime Configuration
 
-Ohkami exposes a few environment variables to tweak runtime behavior when running on a native async runtime.
+Ohkami exposes a few environment variables to tweak runtime behavior when
+running on a native async runtime.
 These options are read at startup and apply to all servers.
 
 - `OHKAMI_REQUEST_BUFSIZE` – maximum size in bytes of the request buffer.
@@ -9,6 +10,10 @@ These options are read at startup and apply to all servers.
   Defaults to **30** seconds.
 - `OHKAMI_WEBSOCKET_TIMEOUT` – WebSocket session timeout in seconds.
   Defaults to **3600** seconds (1 hour) and only applies with the `ws` feature.
+
+Set each variable before launching the server. They are loaded once when the 
+[`CONFIG`](../ohkami-0.24/ohkami/src/config.rs) static initializes so runtime changes are ignored.
+These options are only used with native runtimes such as `rt_tokio` or `rt_smol`.
 
 Values are parsed once using `LazyLock`. Invalid or missing variables fall back
 to the defaults above. Increase these numbers if clients send large headers or

--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -15,7 +15,8 @@ It highlights which modules are documented and notes areas that still need work.
 - `ohkami/src/lib.rs::prelude` – imports covered in [PRELUDE_v0.24](PRELUDE_v0.24.md).
 - `ohkami/src/ohkami/dir` – static file serving in [DIR_v0.24](DIR_v0.24.md).
 - `ohkami/src/config` – environment variables documented in
-  [CONFIGURATION_v0.24](CONFIGURATION_v0.24.md).
+  [CONFIGURATION_v0.24](CONFIGURATION_v0.24.md). Values are loaded once at
+  startup through the [`CONFIG`](../ohkami-0.24/ohkami/src/config.rs) static.
 - `ohkami/src/router` – tree structure and lookup process described in
   [ROUTER_v0.24](ROUTER_v0.24.md).
 

--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -10,7 +10,7 @@ Each item should be checked off once the guide has been reviewed against the
 - [ ] Review `BENCHES_v0.24.md`
 - [ ] Review `CODE_STYLE_v0.24.md`
 - [ ] Review `CODING_GUIDE_v0.24.md`
-- [ ] Review `CONFIGURATION_v0.24.md`
+- [x] Review `CONFIGURATION_v0.24.md`
 - [ ] Review `DIR_v0.24.md`
 - [ ] Review `DOCS_ROADMAP.md`
 - [ ] Review `DOCS_TODO_v0.24.md`


### PR DESCRIPTION
## Summary
- document that environment variables must be set before startup
- note that runtime options work only with native runtimes
- link to the CONFIG static in source
- mark CONFIGURATION file as reviewed in docs todo list
- mention CONFIG static in the docs roadmap

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685d938f7bc4832e8a71b654cb43c33b