### PR TITLE
Add details about Dir fang

### DIFF
--- a/docs/DIR_v0.24.md
+++ b/docs/DIR_v0.24.md
@@ -1,8 +1,15 @@
 # Static Directory Serving
 
-Ohkami ships with a built-in `Dir` fang for serving files from a directory on native runtimes. It lives in [`ohkami/src/ohkami/dir.rs`](../ohkami-0.24/ohkami/src/ohkami/dir.rs) and is enabled automatically when you use the `rt_*` features.
+Ohkami ships with a built-in `Dir` fang for serving files from a directory on
+native runtimes. It lives in
+[`ohkami/src/ohkami/dir.rs`](../ohkami-0.24/ohkami/src/ohkami/dir.rs) and is
+enabled automatically when you use the `rt_*` features.
 
-`Dir` mounts a folder at a path and responds with files beneath that folder. It automatically sets `Content-Type`, `ETag` and `Last-Modified` headers and understands pre-compressed `.gz` and `.br` versions of files.
+`Dir` mounts a folder at a path and responds with files beneath that folder. When
+the fang is created the directory is scanned and every file is opened. This means
+no filesystem work happens during each request. `Dir` automatically sets
+`Content-Type`, `ETag` and `Last-Modified` headers and understands pre-compressed
+files such as `.gz`, `.br` and `.zst`.
 
 ## Basic Usage
 
@@ -22,14 +29,33 @@ async fn main() {
 `Dir` exposes a few builder methods:
 
 - `.serve_dotfiles(bool)` – allow files starting with a dot (`.`). Defaults to `false`.
-- `.omit_extensions(&["html"])` – hide specific extensions so requests for `/index` serve `index.html`.
+- `.omit_extensions(&["html"])` – hide specific extensions so requests for
+  `/index` serve `index.html`.
 - `.etag(fn(&File) -> String)` – supply a custom function to generate an `ETag` value.
 
-Pre-compressed files with extensions like `.gz` or `.br` are preferred when the client sends an `Accept-Encoding` header. If none of the prepared encodings are accepted and the client forbids `identity`, the handler returns **406 Not Acceptable**.
+Example `ETag` generator using SHA-256:
 
-Caching headers are respected: matching `If-None-Match` or `If-Modified-Since` results in **304 Not Modified**.
+```rust
+fn sha_etag(file: &File) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut &*file.try_clone().unwrap(), &mut hasher).unwrap();
+    format!("\"{:x}\"", hasher.finalize())
+}
+```
 
-`Dir` only works on native runtimes because Workers cannot access the local filesystem. When targeting Cloudflare Workers consider using Wrangler's `asset` feature instead.
+Pre-compressed files with extensions like `.gz` or `.br` are preferred when the
+client sends an `Accept-Encoding` header. Outdated compressed files older than
+the source are ignored and the remaining options are tried from smallest to
+largest. If none match and the client forbids `identity`, the handler returns
+**406 Not Acceptable**.
+
+Caching headers are respected: matching `If-None-Match` or `If-Modified-Since`
+results in **304 Not Modified**.
+
+`Dir` only works on native runtimes because Workers cannot access the local
+filesystem. When targeting Cloudflare Workers consider using Wrangler's `asset`
+feature instead.
 
 ## Example with Options
 
@@ -46,4 +72,5 @@ async fn main() {
 }
 ```
 
-This serves `index.html` at `/` and `/about.html` at `/about`. Dotfiles under `./public` are accessible.
+This serves `index.html` at `/` and `/about.html` at `/about`. Dotfiles under
+`./public` are accessible.

--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -18,7 +18,8 @@ It highlights which modules are documented and notes areas that still need work.
 - `ohkami/src/typed` â explained in [TYPED_v0.24](TYPED_v0.24.md).
 - `ohkami/src/lib.rs` â crate root documented in the main README.
 - `ohkami/src/lib.rs::prelude` â imports covered in [PRELUDE_v0.24](PRELUDE_v0.24.md).
-- `ohkami/src/ohkami/dir` â static file serving in [DIR_v0.24](DIR_v0.24.md).
+- `ohkami/src/ohkami/dir` — static file serving in [DIR_v0.24](DIR_v0.24.md),
+ including notes on preloading, compression and cache headers.
 - `ohkami/src/config` â environment variables documented in
   [CONFIGURATION_v0.24](CONFIGURATION_v0.24.md). Values are loaded once at
   startup through the [`CONFIG`](../ohkami-0.24/ohkami/src/config.rs) static.

--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -11,7 +11,7 @@ Each item should be checked off once the guide has been reviewed against the
 - [ ] Review `CODE_STYLE_v0.24.md`
 - [ ] Review `CODING_GUIDE_v0.24.md`
 - [x] Review `CONFIGURATION_v0.24.md`
-- [ ] Review `DIR_v0.24.md`
+- [x] Review `DIR_v0.24.md`
 - [ ] Review `DOCS_ROADMAP.md`
 - [ ] Review `DOCS_TODO_v0.24.md`
 - [x] Review `ERROR_HANDLING_v0.24.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,10 +17,12 @@ Use these guides when exploring version **0.24**.
 - [FANGS_v0.24.md](FANGS_v0.24.md) — overview of builtin middleware.
 - [FORMAT_v0.24.md](FORMAT_v0.24.md) — request/response body helpers.
 - [HEADERS_v0.24.md](HEADERS_v0.24.md) — common header utilities.
-- [DIR_v0.24.md](DIR_v0.24.md) — serving static files from a directory.
+- [DIR_v0.24.md](DIR_v0.24.md) — static directory fang with preloading,
+  compression and caching details.
 - [REQUEST_v0.24.md](REQUEST_v0.24.md) — request structure, context store and extraction.
 - [RESPONSE_v0.24.md](RESPONSE_v0.24.md) — building responses.
-- [ERROR_HANDLING_v0.24.md](ERROR_HANDLING_v0.24.md) — custom error enums and the `IntoResponse` trait.
+- [ERROR_HANDLING_v0.24.md](ERROR_HANDLING_v0.24.md) — custom error enums and
+  the `IntoResponse` trait.
 - [TYPED_v0.24.md](TYPED_v0.24.md) — typed statuses and headers.
 - [OPENAPI_v0.24.md](OPENAPI_v0.24.md) — generating OpenAPI documentation.
 - [TLS_v0.24.md](TLS_v0.24.md) — HTTPS support.


### PR DESCRIPTION
## Summary
- expand `DIR_v0.24.md` with information about preloading files, Accept-Encoding behavior and a sample `ETag` generator
- note new details in `docs/README.md`
- update roadmap entry for static directory fang
- mark `DIR_v0.24.md` as reviewed in `DOCS_TODO_v0.24.md`

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_b_685dada62dfc832e832ba3350feaf0a8