### PR TITLE
Expand response docs

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -12,9 +12,9 @@ It highlights which modules are documented and notes areas that still need work.
   [PATTERNS_v0.24](PATTERNS_v0.24.md).
 - `ohkami/src/testing` â usage described in both guides above.
 - `ohkami/src/tls` â setup instructions in [STARTUP_GUIDE_v0.24](STARTUP_GUIDE_v0.24.md).
-- `ohkami/src/request` and `ohkami/src/response` â detailed in
+- `ohkami/src/request` and `ohkami/src/response` – detailed in
   [REQUEST_v0.24](REQUEST_v0.24.md) (context store and payload limits) and
-  [RESPONSE_v0.24](RESPONSE_v0.24.md).
+  [RESPONSE_v0.24](RESPONSE_v0.24.md) (body helpers and typed statuses).
 - `ohkami/src/typed` â explained in [TYPED_v0.24](TYPED_v0.24.md).
 - `ohkami/src/lib.rs` â crate root documented in the main README.
 - `ohkami/src/lib.rs::prelude` â imports covered in [PRELUDE_v0.24](PRELUDE_v0.24.md).

--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -27,7 +27,7 @@ Each item should be checked off once the guide has been reviewed against the
 - [ ] Review `PRELUDE_v0.24.md`
 - [ ] Review `README.md`
 - [x] Review `REQUEST_v0.24.md`
-- [ ] Review `RESPONSE_v0.24.md`
+- [x] Review `RESPONSE_v0.24.md`
 - [ ] Review `ROUTER_v0.24.md`
 - [ ] Review `RUNTIME_ADAPTERS_v0.24.md`
 - [ ] Review `SAMPLES_v0.24.md`

--- a/docs/RESPONSE_v0.24.md
+++ b/docs/RESPONSE_v0.24.md
@@ -1,6 +1,8 @@
 # HTTP Responses
 
-The [`response`](../ohkami-0.24/ohkami/src/response) module defines the [`Response`](../ohkami-0.24/ohkami/src/response/mod.rs) type returned from handlers.
+A response is created using the [`response`](../ohkami-0.24/ohkami/src/response)
+module. The central [`Response`](../ohkami-0.24/ohkami/src/response/mod.rs) type
+is returned from handlers.
 A response is composed of a status code, headers and an optional body.
 
 Key pieces:
@@ -20,8 +22,9 @@ async fn handler() -> Response {
 }
 ```
 
-Middleware can modify headers by calling `res.headers.set()` in their `back` method.
-When the `sse` feature is active a handler may return a streaming body and the framework handles chunked encoding automatically.
+Middleware can modify headers by calling `res.headers.set()` in their `back`
+method. When the `sse` feature is active a handler may return a streaming body
+and the framework handles chunked encoding automatically.
 
 For convenience the `typed::status` module defines constructors like
 `status::Created` and `status::NoContent` which return lightweight wrappers
@@ -29,4 +32,19 @@ implementing `IntoResponse`.  Prefer these helpers when you simply need to send
 a standard status code.
 
 Review the documentation comments in `response/mod.rs` for details on WebSocket and SSE support.
+
+## Building Bodies
+
+`Response` exposes helpers for common content types. `with_text` and `with_html`
+set the `Content-Type` header and store the provided string. `with_json`
+serializes any `serde::Serialize` value using `serde_json`. For raw bytes use
+`with_payload(content_type, bytes)`. When the `sse` feature is active
+`with_stream` streams `Data` items as Server‑Sent Events.
+
+The body can be inspected with `payload()` or removed using `drop_content()`.
+Calling `without_content()` returns the modified response.
+
+`ResponseHeaders` offers typed setters for standard headers. For example
+`res.headers.set().Server("ohkami")` or
+`res.headers.set().x("X-Foo", "bar")`.
 


### PR DESCRIPTION
## Summary
- document more response helpers for building bodies
- mark RESPONSE_v0.24.md as reviewed in the TODO list
- note typed statuses in roadmap

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685db76979f4832e984976802ea9ba45