### PR TITLE
Document Testing API

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -10,7 +10,7 @@ It highlights which modules are documented and notes areas that still need work.
   [FANGS_v0.24](FANGS_v0.24.md) (builder method details added),
   [CODING_GUIDE_v0.24](CODING_GUIDE_v0.24.md) and
   [PATTERNS_v0.24](PATTERNS_v0.24.md).
-- `ohkami/src/testing` â usage described in both guides above.
+- `ohkami/src/testing` — explained in [TESTING_v0.24](TESTING_v0.24.md).
 - `ohkami/src/tls` â setup instructions in [STARTUP_GUIDE_v0.24](STARTUP_GUIDE_v0.24.md).
 - `ohkami/src/request` and `ohkami/src/response` – detailed in
   [REQUEST_v0.24](REQUEST_v0.24.md) (context store and payload limits) and

--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -35,7 +35,7 @@ Each item should be checked off once the guide has been reviewed against the
 - [x] Review `SSE_v0.24.md`
 - [ ] Review `STARTUP_GUIDE_v0.24.md`
 - [ ] Review `TASKS_v0.24.md`
-- [ ] Review `TESTING_v0.24.md`
+- [x] Review `TESTING_v0.24.md`
 - [ ] Review `TLS_v0.24.md`
 - [ ] Review `TYPED_v0.24.md`
 - [x] Review `UTILS_v0.24.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ Use these guides when exploring version **0.24**.
 - [TYPED_v0.24.md](TYPED_v0.24.md) — typed statuses and headers.
 - [OPENAPI_v0.24.md](OPENAPI_v0.24.md) — generating OpenAPI documentation.
 - [TLS_v0.24.md](TLS_v0.24.md) — HTTPS support.
-- [TESTING_v0.24.md](TESTING_v0.24.md) — running handlers without sockets.
+- [TESTING_v0.24.md](TESTING_v0.24.md) — debug-only in-memory harness for calling routes.
 - [WS_v0.24.md](WS_v0.24.md) — upgrading connections to WebSockets.
 - [SSE_v0.24.md](SSE_v0.24.md) — streaming Server‑Sent Events.
 - [ROUTER_v0.24.md](ROUTER_v0.24.md) — how routes are organized and finalized.

--- a/docs/TESTING_v0.24.md
+++ b/docs/TESTING_v0.24.md
@@ -1,8 +1,11 @@
 # Testing Helpers
 
-Under debug builds Ohkami exposes a lightweight test harness in the [`testing`](../ohkami-0.24/ohkami/src/testing/mod.rs) module. It allows exercising routes without opening sockets.
+Under debug builds Ohkami provides a lightweight test harness.
+It lives in the [`testing`](../ohkami-0.24/ohkami/src/testing/mod.rs) module.
+It lets you exercise routes without opening sockets.
 
-Create your application and call `.test()` on it to get a `TestingOhkami` instance. Use `TestRequest` to build requests and `.oneshot()` to execute them.
+Create your application and call `.test()` on it to get a `TestingOhkami` instance.
+Use `TestRequest` to build requests and `.oneshot()` to execute them.
 
 ```rust
 use ohkami::prelude::*;
@@ -20,4 +23,16 @@ async fn test_index() {
 }
 ```
 
-`TestRequest` supports adding query parameters, headers and JSON bodies for exercising your handlers.
+`TestRequest` can add query parameters or headers.
+It also attaches JSON bodies for exercising handlers.
+
+In addition to `query` and `header` there are helpers `json` and `json_lit` for adding bodies.
+Use `content` to send arbitrary bytes with a custom type.
+`json` takes any `Serialize` value, `json_lit` accepts raw JSON bytes, and
+`content` lets you set an arbitrary content type with bytes.
+
+`oneshot` returns a future resolving to `TestResponse`.
+Use `status`, `header`, `text`, `html` or `json` to inspect the response.
+
+The testing module is compiled only when `debug_assertions` are enabled.
+The harness is unavailable in release builds.


### PR DESCRIPTION
## Summary
- flesh out TESTING_v0.24.md with more details
- mark testing guide complete in TODO
- link testing doc from docs roadmap
- clarify testing entry in docs README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685dc5b33fe4832e857fbd78f752f0e1