### PR TITLE
Document runtime adapters

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -28,7 +28,8 @@ It highlights which modules are documented and notes areas that still need work.
 
 - `ohkami/src/session` â lifecycle explained in [SESSION_v0.24](SESSION_v0.24.md).
 - Cloud runtime adapters (`x_worker`, `x_lambda`) documented in
-  [RUNTIME_ADAPTERS_v0.24](RUNTIME_ADAPTERS_v0.24.md).
+  [RUNTIME_ADAPTERS_v0.24](RUNTIME_ADAPTERS_v0.24.md) now include
+  examples for `#[bindings]` and Lambda WebSocket handling.
 - `util` helpers and the `ohkami_lib` crate covered in [UTILS_v0.24](UTILS_v0.24.md).
 - Error conversions via `IntoResponse` documented in
   [ERROR_HANDLING_v0.24](ERROR_HANDLING_v0.24.md).

--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -29,7 +29,7 @@ Each item should be checked off once the guide has been reviewed against the
 - [x] Review `REQUEST_v0.24.md`
 - [x] Review `RESPONSE_v0.24.md`
 - [x] Review `ROUTER_v0.24.md`
-- [ ] Review `RUNTIME_ADAPTERS_v0.24.md`
+- [x] Review `RUNTIME_ADAPTERS_v0.24.md`
 - [ ] Review `SAMPLES_v0.24.md`
 - [ ] Review `SESSION_v0.24.md`
 - [x] Review `SSE_v0.24.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,8 @@ Use these guides when exploring version **0.24**.
 - [PATTERNS_v0.24.md](PATTERNS_v0.24.md) — useful idioms taken from the implementation.
 - [ARCHITECTURE_v0.24.md](ARCHITECTURE_v0.24.md) — overview of crate modules.
 - [SESSION_v0.24.md](SESSION_v0.24.md) — how connections are managed.
-- [RUNTIME_ADAPTERS_v0.24.md](RUNTIME_ADAPTERS_v0.24.md) — deploying to Workers or Lambda.
+- [RUNTIME_ADAPTERS_v0.24.md](RUNTIME_ADAPTERS_v0.24.md) — deploying to
+  Workers or Lambda with examples.
 - [UTILS_v0.24.md](UTILS_v0.24.md) — helper functions and utility crate (stream,
   slice, num and time modules).
 - [MACROS_v0.24.md](MACROS_v0.24.md) — derives plus OpenAPI and Workers macros.

--- a/docs/RUNTIME_ADAPTERS_v0.24.md
+++ b/docs/RUNTIME_ADAPTERS_v0.24.md
@@ -1,20 +1,58 @@
 # Cloud Runtime Adapters
 
-Ohkami can run inside serverless environments through optional adapters. These live in [`x_worker.rs`](../ohkami-0.24/ohkami/src/x_worker.rs) and [`x_lambda.rs`](../ohkami-0.24/ohkami/src/x_lambda.rs).
+Ohkami can run inside serverless environments through optional adapters. These
+live in [`x_worker.rs`](../ohkami-0.24/ohkami/src/x_worker.rs) and
+[`x_lambda.rs`](../ohkami-0.24/ohkami/src/x_lambda.rs).
 
 ## Cloudflare Workers
 
-Enabling the `rt_worker` feature exposes utilities for the [workers-rs](https://github.com/cloudflare/workers-rs) runtime:
+Enabling the `rt_worker` feature exposes utilities for the
+[workers-rs](https://github.com/cloudflare/workers-rs) runtime:
 
-- Procedural macros `#[worker]` and `#[DurableObject]` connect Ohkami routes to Cloudflare entry points.
-- The `FromEnv` trait lets you extract bindings (KV stores, queues, etc.) from the worker environment.
-- Durable Objects implement a trait with async hooks like `fetch`, `websocket_message`, and `alarm`.
+ - Procedural macros `#[worker]` and `#[DurableObject]` connect Ohkami routes to
+   Cloudflare entry points.
+ - The `FromEnv` trait lets you extract bindings (KV stores, queues, etc.) from
+   the worker environment.
+ - Durable Objects implement a trait with async hooks like `fetch`,
+   `websocket_message`, and `alarm`.
+
+`#[bindings]` can generate a struct with fields for bindings defined in your
+`wrangler.toml` so you can access them via the `worker` crate without manual
+boilerplate. All three macros live in the
+[`ohkami_macros`](../ohkami-0.24/ohkami_macros/src) crate.
+
+```rust
+#[ohkami::bindings]
+struct Bindings;
+
+#[ohkami::worker]
+async fn app() -> ohkami::Ohkami {
+    Ohkami::new(("/".GET(|| async { "hi" })))
+}
+```
 
 See the inline examples in `x_worker.rs` for a full setup.
 
 ## AWS Lambda
 
-When built with the `rt_lambda` feature Ohkami integrates with `lambda_runtime` through types in `x_lambda.rs`.
-It defines `LambdaHTTPRequest` and `LambdaResponse` structs compatible with API Gateway and provides a basic WebSocket client for AWS' WebSocket APIs. An adapter to map between Lambda events and Ohkami `Request`/`Response` types is planned but not yet finalized.
+When built with the `rt_lambda` feature Ohkami integrates with
+`lambda_runtime` through types in `x_lambda.rs`.
+It defines `LambdaHTTPRequest` and `LambdaResponse` structs compatible with API
+Gateway and provides a basic WebSocket client for AWS' WebSocket APIs.
+`Ohkami` implements `lambda_runtime::Service`, so you simply pass an instance to
+`lambda_runtime::run`:
 
-These modules allow deploying the same application logic to native servers or serverless platforms with minimal changes.
+```rust
+#[tokio::main]
+async fn main() -> Result<(), lambda_runtime::Error> {
+    lambda_runtime::run(my_ohkami()).await
+}
+```
+
+With the `ws` feature enabled you can handle API Gateway WebSocket events using
+`LambdaWebSocket::handle`.
+An adapter to map between Lambda events and Ohkami `Request`/`Response` types is
+planned but not yet finalized.
+
+These modules let you deploy the same application logic to native servers or
+serverless platforms with minimal changes.


### PR DESCRIPTION
## Summary
- expand `RUNTIME_ADAPTERS_v0.24.md` with details about `#[bindings]` and Lambda integration
- note runtime adapter examples in docs roadmap
- mark the doc as reviewed in the todo list
- clarify runtime adapters entry in docs README

## Testing
- `git diff --cached --stat`

------
https://chatgpt.com/codex/tasks/task_b_685dd1833a4c832e85be4a72f35d1e77