### PR TITLE
Document TLS feature usage

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -11,7 +11,7 @@ It highlights which modules are documented and notes areas that still need work.
   [CODING_GUIDE_v0.24](CODING_GUIDE_v0.24.md) and
   [PATTERNS_v0.24](PATTERNS_v0.24.md).
 - `ohkami/src/testing` — explained in [TESTING_v0.24](TESTING_v0.24.md).
-- `ohkami/src/tls` â setup instructions in [STARTUP_GUIDE_v0.24](STARTUP_GUIDE_v0.24.md).
+- `ohkami/src/tls` — usage documented in [TLS_v0.24](TLS_v0.24.md).
 - `ohkami/src/request` and `ohkami/src/response` – detailed in
   [REQUEST_v0.24](REQUEST_v0.24.md) (context store and payload limits) and
   [RESPONSE_v0.24](RESPONSE_v0.24.md) (body helpers and typed statuses).

--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -36,7 +36,7 @@ Each item should be checked off once the guide has been reviewed against the
 - [ ] Review `STARTUP_GUIDE_v0.24.md`
 - [ ] Review `TASKS_v0.24.md`
 - [x] Review `TESTING_v0.24.md`
-- [ ] Review `TLS_v0.24.md`
+- [x] Review `TLS_v0.24.md`
 - [ ] Review `TYPED_v0.24.md`
 - [x] Review `UTILS_v0.24.md`
 - [ ] Review `WS_v0.24.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ Use these guides when exploring version **0.24**.
   the `IntoResponse` trait.
 - [TYPED_v0.24.md](TYPED_v0.24.md) — typed statuses and headers.
 - [OPENAPI_v0.24.md](OPENAPI_v0.24.md) — generating OpenAPI documentation.
-- [TLS_v0.24.md](TLS_v0.24.md) — HTTPS support.
+- [TLS_v0.24.md](TLS_v0.24.md) — HTTPS support via `rustls` using `howls`.
 - [TESTING_v0.24.md](TESTING_v0.24.md) — debug-only in-memory harness for calling routes.
 - [WS_v0.24.md](WS_v0.24.md) — upgrading connections to WebSockets.
 - [SSE_v0.24.md](SSE_v0.24.md) — streaming Server‑Sent Events.

--- a/docs/TLS_v0.24.md
+++ b/docs/TLS_v0.24.md
@@ -1,8 +1,12 @@
 # TLS Support
 
-Feature `tls` enables HTTPS servers using [rustls](https://github.com/rustls). The implementation wraps a TCP stream in [`TlsStream`](../ohkami-0.24/ohkami/src/tls/mod.rs) which implements the `Connection` trait used by `Session`.
+The `tls` feature enables HTTPS servers using [rustls](https://github.com/rustls).
+It requires the `rt_tokio` runtime and wraps each TCP connection in
+[`TlsStream`](../ohkami-0.24/ohkami/src/tls/mod.rs). `TlsStream` implements the
+`Connection` trait consumed by `Session`.
 
-To run a server over TLS call `howls` instead of `howl` and provide a configured `ServerConfig`:
+Run a server over TLS by calling `howls` instead of `howl` and passing a
+`rustls::ServerConfig`:
 
 ```rust,no_run
 use ohkami::prelude::*;
@@ -21,4 +25,8 @@ async fn main() {
 }
 ```
 
-Currently TLS only works with the `rt_tokio` runtime and HTTP/1.1. See the README in `ohkami-0.24` for a complete example including certificate loading.
+`howls` performs the TLS handshake using `tokio_rustls::TlsAcceptor` and serves
+HTTP/1.1 responses. WebSocket upgrades are not supported over TLS yet.
+
+For a complete certificate loading example see the
+[README](../ohkami-0.24/README.md#tls).


### PR DESCRIPTION
## Summary
- document how to serve HTTPS with `howls` in TLS_v0.24
- reference the new TLS doc from DOCS_ROADMAP and README
- mark TLS doc complete in DOCS_TODO

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685dd34560c8832e997437aa365eea5d