### PR TITLE
Update Prelude docs

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -17,7 +17,8 @@ It highlights which modules are documented and notes areas that still need work.
   [RESPONSE_v0.24](RESPONSE_v0.24.md) (body helpers and typed statuses).
 - `ohkami/src/typed` â explained in [TYPED_v0.24](TYPED_v0.24.md).
 - `ohkami/src/lib.rs` â crate root documented in the main README.
-- `ohkami/src/lib.rs::prelude` â imports covered in [PRELUDE_v0.24](PRELUDE_v0.24.md).
+- `ohkami/src/lib.rs::prelude` — exports documented in [PRELUDE_v0.24](PRELUDE_v0.24.md)
+  with notes on runtime gating.
 - `ohkami/src/ohkami/dir` — static file serving in [DIR_v0.24](DIR_v0.24.md),
  including notes on preloading, compression and cache headers.
 - `ohkami/src/config` â environment variables documented in

--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -24,7 +24,7 @@ Each item should be checked off once the guide has been reviewed against the
 - [ ] Review `NOTES_FROM_SOURCE_v0.24.md`
 - [ ] Review `OPENAPI_v0.24.md`
 - [ ] Review `PATTERNS_v0.24.md`
-- [ ] Review `PRELUDE_v0.24.md`
+- [x] Review `PRELUDE_v0.24.md`
 - [ ] Review `README.md`
 - [x] Review `REQUEST_v0.24.md`
 - [x] Review `RESPONSE_v0.24.md`

--- a/docs/PRELUDE_v0.24.md
+++ b/docs/PRELUDE_v0.24.md
@@ -1,17 +1,24 @@
 # Prelude Module
 
-The [`prelude`](../ohkami-0.24/ohkami/src/lib.rs) re-exports the most common
-traits and types so examples can simply `use ohkami::prelude::*`.
-This keeps boilerplate low when writing handlers.
+The [`prelude`](../ohkami-0.24/ohkami/src/lib.rs) collects the most frequently
+used pieces of the framework.  By importing `ohkami::prelude::*` examples can
+stay concise without a long list of `use` statements.
 
 ## What it Contains
 
-- `Request`, `Response`, `IntoResponse`, `Method` and `Status`
-- [`FangAction`](../ohkami-0.24/ohkami/src/util.rs) for middleware control
-- The `Serialize` and `Deserialize` derives from `ohkami_macros`
-- Format helpers like [`JSON`] and [`Query`](../ohkami-0.24/ohkami/src/format)
-- `Context` for fangs
-- `Route` and `Ohkami` when a runtime feature is active
+- `Request`, `Response`, `IntoResponse`, `Method` and `Status` –
+  core HTTP types.
+- [`FangAction`](../ohkami-0.24/ohkami/src/util.rs) – trait for building and
+  chaining middleware.
+- `Serialize` and `Deserialize` derives from
+  [`ohkami_macros`](../ohkami-0.24/ohkami_macros/src/lib.rs).  These mirror the
+  `serde` macros so you do not need to depend on `serde` directly.
+- Format helpers [`JSON`] and [`Query`](../ohkami-0.24/ohkami/src/format) for
+  request extraction and response bodies.
+- [`Context`](../ohkami-0.24/ohkami/src/fang/builtin/context.rs) – typed storage
+  available inside a request for fangs and handlers.
+- `Route` and `Ohkami` when a runtime feature (e.g. `rt_tokio`) is enabled,
+  letting you construct routers and launch the server.
 
 ## Example
 
@@ -28,4 +35,5 @@ async fn main() {
 }
 ```
 
-The prelude is optional; you can import items individually if you prefer explicit paths.
+Importing from the prelude is optional.  You can use the individual paths if you
+prefer explicit imports.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ Use these guides when exploring version **0.24**.
 - [STARTUP_GUIDE_v0.24.md](STARTUP_GUIDE_v0.24.md) — installation and running your first server.
 - [CODING_GUIDE_v0.24.md](CODING_GUIDE_v0.24.md) — walkthrough of common APIs and patterns.
 - [CODE_STYLE_v0.24.md](CODE_STYLE_v0.24.md) — conventions used throughout the code base.
-- [PRELUDE_v0.24.md](PRELUDE_v0.24.md) — common re‑exports used in examples.
+- [PRELUDE_v0.24.md](PRELUDE_v0.24.md) — common re‑exports and runtime helpers.
 - [PATTERNS_v0.24.md](PATTERNS_v0.24.md) — useful idioms taken from the implementation.
 - [ARCHITECTURE_v0.24.md](ARCHITECTURE_v0.24.md) — overview of crate modules.
 - [SESSION_v0.24.md](SESSION_v0.24.md) — how connections are managed.


### PR DESCRIPTION
## Summary
- document runtime gated exports in PRELUDE_v0.24
- check off PRELUDE_v0.24 in the todo list
- tweak docs roadmap and README to reflect new detail

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_b_685dd6bb6ad8832eb1156ab6e6e5b19b