### PR TITLE
Add WebSocket worker notes

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -48,8 +48,9 @@ It highlights which modules are documented and notes areas that still need work.
 
 ## Partially Documented
 - `format`, `header`, and `ws` plus portions of the router internals now
-include example code in their docs. `sse` recently gained a section on
-`DataStream::from` and custom `Data` implementations.
+include example code in their docs. The WebSocket guide covers
+`upgrade_durable` and the `SessionMap` helper for Workers. `sse` recently
+gained a section on `DataStream::from` and custom `Data` implementations.
 The header guide covers `AcceptEncoding` parsing and `Set-Cookie`
 iteration. Further real‑world guides are still welcome. `Dir` was recently
 documented but additional recipes are encouraged.

--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -39,7 +39,7 @@ Each item should be checked off once the guide has been reviewed against the
 - [x] Review `TLS_v0.24.md`
 - [ ] Review `TYPED_v0.24.md`
 - [x] Review `UTILS_v0.24.md`
-- [ ] Review `WS_v0.24.md`
+- [x] Review `WS_v0.24.md`
 
 ## Examples
 - [ ] Review `examples/README.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ Use these guides when exploring version **0.24**.
 - [OPENAPI_v0.24.md](OPENAPI_v0.24.md) — generating OpenAPI documentation.
 - [TLS_v0.24.md](TLS_v0.24.md) — HTTPS support via `rustls` using `howls`.
 - [TESTING_v0.24.md](TESTING_v0.24.md) — debug-only in-memory harness for calling routes.
-- [WS_v0.24.md](WS_v0.24.md) — upgrading connections to WebSockets.
+- [WS_v0.24.md](WS_v0.24.md) — upgrading connections to WebSockets and Workers.
 - [SSE_v0.24.md](SSE_v0.24.md) — streaming Server‑Sent Events.
 - [ROUTER_v0.24.md](ROUTER_v0.24.md) — how routes are organized and finalized.
 - [FEATURE_FLAGS_v0.24.md](FEATURE_FLAGS_v0.24.md) — optional Cargo features.

--- a/docs/WS_v0.24.md
+++ b/docs/WS_v0.24.md
@@ -35,6 +35,12 @@ loop {
 the underlying `mews` crate if you need control over frame sizes or ping
 timeouts.
 
+On Cloudflare Workers the context also exposes `upgrade_durable` and
+`upgrade_durable_with`. These helpers connect a WebSocket to a Durable Object
+instance and return a `WebSocket` response.
+The [`SessionMap`](../ohkami-0.24/ohkami/src/ws/worker.rs)
+type can be used inside the object to track active sessions.
+
 
 
 
@@ -59,3 +65,21 @@ async fn main() {
     Ohkami::new(("/ws".GET(echo))).howl("localhost:4040").await;
 }
 ```
+
+### Cloudflare Durable Object
+
+When targeting Workers you may connect a WebSocket to a Durable Object via
+`upgrade_durable`:
+
+```rust,no_run
+async fn ws_chatroom(ctx: WebSocketContext<'_>, room: worker::Stub)
+    -> Result<WebSocket, worker::Error>
+{
+    ctx.upgrade_durable(room).await
+}
+```
+
+Inside the object a [`SessionMap`](../ohkami-0.24/ohkami/src/ws/worker.rs)
+stores metadata about connected sockets, allowing them to be resumed after
+hibernation.
+


### PR DESCRIPTION
## Summary
- detail Cloudflare Durable Object support in WS docs
- update roadmap and todo list
- describe WebSocket worker support in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685df3639544832ebe9d6d028c01a672