### PR TITLE
Document typed redirect helpers

### DIFF
--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -37,7 +37,7 @@ Each item should be checked off once the guide has been reviewed against the
 - [x] Review `TASKS_v0.24.md`
 - [x] Review `TESTING_v0.24.md`
 - [x] Review `TLS_v0.24.md`
-- [ ] Review `TYPED_v0.24.md`
+ - [x] Review `TYPED_v0.24.md`
 - [x] Review `UTILS_v0.24.md`
 - [x] Review `WS_v0.24.md`
 

--- a/docs/TYPED_v0.24.md
+++ b/docs/TYPED_v0.24.md
@@ -60,3 +60,31 @@ async fn api(header::Authorization(BearerToken(token)): header::Authorization<Be
 ```
 
 The `Cookie` wrapper works similarly but parses the header into a struct that implements `Deserialize`. See the source for more details.
+
+## Redirect Responses
+
+Several status helpers represent redirects and require a `Location` header. Construct them with the target URL:
+
+```rust,no_run
+use ohkami::typed::status;
+
+async fn go_home() -> status::Found {
+    status::Found::at("/")
+}
+```
+
+The `at` and `to` constructors create `Found`, `MovedPermanently`, `TemporaryRedirect` and `PermanentRedirect` types. They implement `IntoResponse` and expose `.with_headers` just like other statuses.
+
+## Empty Body Statuses
+
+For responses that carry no body, types such as `NoContent` and `Accepted` can be returned directly without parameters:
+
+```rust
+use ohkami::typed::status;
+
+async fn ping() -> status::NoContent {
+    status::NoContent
+}
+```
+
+These ensure consistent headers while avoiding manual `Response` creation.


### PR DESCRIPTION
## Summary
- document typed status redirect constructors and empty-body status helpers
- mark TODO item complete

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_b_685e1ed1d86c832e8faa7d6521735788