### PR TITLE
Update quick start docs

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -41,6 +41,7 @@ It highlights which modules are documented and notes areas that still need work.
 - Dependency injection and typed error patterns now covered in
   [PATTERNS_v0.24](PATTERNS_v0.24.md).
 - Example projects under `samples/` summarized in [SAMPLES_v0.24](SAMPLES_v0.24.md).
+- Quick start server documented in [examples/quick_start.md](examples/quick_start.md).
 - `Taskfile.yaml` tasks explained in [TASKS_v0.24](TASKS_v0.24.md) including check, test and bench.
 - Benchmark crates explained in [BENCHES_v0.24](BENCHES_v0.24.md), including lists
   of micro benchmark modules and runtime comparison crates.

--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -52,7 +52,7 @@ Each item should be checked off once the guide has been reviewed against the
 - [ ] Review `examples/json_response.md`
 - [ ] Review `examples/jwt.md`
 - [ ] Review `examples/multiple-single-threads.md`
-- [ ] Review `examples/quick_start.md`
+- [x] Review `examples/quick_start.md`
 - [ ] Review `examples/sse.md`
 - [ ] Review `examples/static_files.md`
 - [ ] Review `examples/websocket.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ Use these guides when exploring version **0.24**.
 - [DOCS_TODO_v0.24.md](DOCS_TODO_v0.24.md) — checklist for verifying each guide.
 - [FEATURE_REQUESTS.md](FEATURE_REQUESTS.md) — ideas for future improvements.
 - [examples/](examples/README.md) — documentation for the example projects.
+  - [quick_start.md](examples/quick_start.md) — minimal starter server.
 - [SAMPLES_v0.24.md](SAMPLES_v0.24.md) — overview of the larger sample projects.
 - [NOTES_FROM_SOURCE_v0.24.md](NOTES_FROM_SOURCE_v0.24.md) — design notes from the source.
 - [../ENV_SETUP.md](../ENV_SETUP.md) — initializing the workspace environment.

--- a/docs/examples/quick_start.md
+++ b/docs/examples/quick_start.md
@@ -1,19 +1,46 @@
 # Quick Start Example
 
-The minimal server used in the README.  Includes a health check endpoint and
-parameterized hello route.  Perfect as a template for new services.
+The minimal server used in the README.  It exposes a `/healthz` endpoint and a
+parameterized `/hello/:name` route.  This example is a good starting point for
+new services.
 
 ## Files
 
 - `Cargo.toml` – declares the `ohkami` dependency.
 - `src/main.rs` – implements the handlers and server setup.
 
+
 ### `src/main.rs`
 
 - `health_check` – returns a `NoContent` status for `/healthz`.
-- `hello` – greets the path parameter captured from `/hello/:name`.
-- the `main` function builds an `Ohkami` instance with the two routes and
-  listens on `localhost:3000`.
+- `hello` – greets the captured name from `/hello/:name`.
+- `main` builds an `Ohkami` instance with the two routes and listens on
+  `localhost:3000`.
+
+```rust
+use ohkami::prelude::*;
+use ohkami::typed::status;
+
+async fn health_check() -> status::NoContent {
+    status::NoContent
+}
+
+async fn hello(name: &str) -> String {
+    format!("Hello, {name}!")
+}
+
+#[tokio::main]
+async fn main() {
+    Ohkami::new((
+        "/healthz".GET(health_check),
+        "/hello/:name".GET(hello),
+    ))
+    .howl("localhost:3000").await
+}
+```
+
+See [`src/main.rs`](../../ohkami-0.24/examples/quick_start/src/main.rs) for the
+complete file.
 
 ```bash
 $ cargo run --example quick_start


### PR DESCRIPTION
## Summary
- expand example guide for quick start
- mark quick start as reviewed in TODO list
- mention quick start in docs index and roadmap

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_b_685eb152bbd4832e84c2cad26bf99831