### PR TITLE
Expand SSE example doc

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -12,7 +12,7 @@ It highlights which modules are documented and notes areas that still need work.
   [PATTERNS_v0.24](PATTERNS_v0.24.md).
 - `ohkami/src/testing` — explained in [TESTING_v0.24](TESTING_v0.24.md).
 - `ohkami/src/tls` — usage documented in [TLS_v0.24](TLS_v0.24.md).
-- `ohkami/src/request` and `ohkami/src/response` – detailed in
+- `ohkami/src/request` and `ohkami/src/response` - detailed in
   [REQUEST_v0.24](REQUEST_v0.24.md) (context store and payload limits) and
   [RESPONSE_v0.24](RESPONSE_v0.24.md) (body helpers and typed statuses).
 - `ohkami/src/typed` â explained in [TYPED_v0.24](TYPED_v0.24.md).
@@ -27,7 +27,8 @@ It highlights which modules are documented and notes areas that still need work.
 - `ohkami/src/router` â tree structure, compression and lookup documented in
   [ROUTER_v0.24](ROUTER_v0.24.md).
 
-- `ohkami/src/session` â lifecycle explained in [SESSION_v0.24](SESSION_v0.24.md) (now includes connection trait details).
+- `ohkami/src/session` - lifecycle explained in [SESSION_v0.24](SESSION_v0.24.md)
+including connection trait details.
 - Cloud runtime adapters (`x_worker`, `x_lambda`) documented in
   [RUNTIME_ADAPTERS_v0.24](RUNTIME_ADAPTERS_v0.24.md) now include
   examples for `#[bindings]` and Lambda WebSocket handling.
@@ -43,6 +44,7 @@ It highlights which modules are documented and notes areas that still need work.
 - Example projects under `samples/` summarized in [SAMPLES_v0.24](SAMPLES_v0.24.md).
 - Quick start server documented in [examples/quick_start.md](examples/quick_start.md).
 - JSON serialization illustrated in [examples/json_response.md](examples/json_response.md).
+- Server‑sent events showcased in [examples/sse.md](examples/sse.md).
 - `Taskfile.yaml` tasks explained in [TASKS_v0.24](TASKS_v0.24.md) including check, test and bench.
 - Benchmark crates explained in [BENCHES_v0.24](BENCHES_v0.24.md), including lists
   of micro benchmark modules and runtime comparison crates.

--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -53,6 +53,6 @@ Each item should be checked off once the guide has been reviewed against the
 - [ ] Review `examples/jwt.md`
 - [ ] Review `examples/multiple-single-threads.md`
 - [x] Review `examples/quick_start.md`
-- [ ] Review `examples/sse.md`
+- [x] Review `examples/sse.md`
 - [ ] Review `examples/static_files.md`
 - [ ] Review `examples/websocket.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,7 @@ Use these guides when exploring version **0.24**.
 - [examples/](examples/README.md) — documentation for the example projects.
   - [quick_start.md](examples/quick_start.md) — minimal starter server.
   - [json_response.md](examples/json_response.md) — typed `JSON` wrapper usage.
+  - [sse.md](examples/sse.md) — streaming events with `DataStream`.
 - [SAMPLES_v0.24.md](SAMPLES_v0.24.md) — overview of the larger sample projects.
 - [NOTES_FROM_SOURCE_v0.24.md](NOTES_FROM_SOURCE_v0.24.md) — design notes from the source.
 - [../ENV_SETUP.md](../ENV_SETUP.md) — initializing the workspace environment.

--- a/docs/examples/sse.md
+++ b/docs/examples/sse.md
@@ -1,17 +1,41 @@
 # Server‑Sent Events Example
 
-Streams a sequence of messages to the client using Ohkami's built‑in SSE
-support.  Each second another event is sent until the stream completes.
+Demonstrates streaming messages to the client with Ohkami's built‑in
+Server‑Sent Events support. The handler sends five events with a one second
+delay between them.
 
 ## Files
 
+- `Cargo.toml` – declares the `ohkami` and `tokio` dependencies.
 - `src/main.rs` – defines a single `/sse` route that returns `DataStream`.
 
 ### `src/main.rs`
 
-`handler` creates a streaming response that emits five messages with a one
-second delay between them. The `main` function mounts this handler and listens
-on `localhost:3020`.
+`handler` creates the streaming response and `main` mounts it under `/sse`.
+
+```rust
+use ohkami::prelude::*;
+use ohkami::sse::DataStream;
+use tokio::time::{sleep, Duration};
+
+async fn handler() -> DataStream {
+    DataStream::new(|mut s| async move {
+        s.send("starting streaming...");
+        for i in 1..=5 {
+            sleep(Duration::from_secs(1)).await;
+            s.send(format!("MESSAGE #{i}"));
+        }
+        s.send("streaming finished!");
+    })
+}
+
+#[tokio::main]
+async fn main() {
+    Ohkami::new(("/sse".GET(handler))).howl("localhost:3020").await
+}
+```
+
+See [`src/main.rs`](../../ohkami-0.24/examples/sse/src/main.rs) for the full file.
 
 ```bash
 $ cargo run --example sse


### PR DESCRIPTION
## Summary
- flesh out `examples/sse.md` with code snippet and detailed notes
- link the SSE example from the main docs README
- add SSE entry in the docs roadmap
- mark the item as reviewed in DOCS_TODO

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685f02a3f510832eb1af9b982ca956db