### PR TITLE
Improve format guide

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -53,7 +53,8 @@ including connection trait details.
 - Workspace setup documented in [../ENV_SETUP.md](../ENV_SETUP.md).
 
 ## Partially Documented
-- `format`, `header`, and `ws` plus portions of the router internals now
+- `format` (including the `bound` traits and a CSV example),
+  `header`, and `ws` plus portions of the router internals now
 include example code in their docs. The WebSocket guide covers
 `upgrade_durable` and the `SessionMap` helper for Workers. `sse` recently
 gained a section on `DataStream::from` and custom `Data` implementations.

--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -18,7 +18,7 @@ Each item should be checked off once the guide has been reviewed against the
  - [x] Review `FANGS_v0.24.md`
 - [x] Review `FEATURE_FLAGS_v0.24.md`
 - [ ] Review `FEATURE_REQUESTS.md`
-- [ ] Review `FORMAT_v0.24.md`
+- [x] Review `FORMAT_v0.24.md`
 - [x] Review `HEADERS_v0.24.md`
 - [x] Review `MACROS_v0.24.md`
 - [ ] Review `NOTES_FROM_SOURCE_v0.24.md`

--- a/docs/FORMAT_v0.24.md
+++ b/docs/FORMAT_v0.24.md
@@ -21,6 +21,11 @@ Each type implements both `FromBody` and `IntoBody` so they can be used for
 request extraction and response generation.  With the `openapi` feature enabled
 these types also provide schema information for documentation.
 
+The [`bound`](../ohkami-0.24/ohkami/src/format/builtin.rs) module
+exposes `Schema`, `Incoming` and `Outgoing` helper traits used by the
+built­in types when OpenAPI generation is enabled. They are re-exported
+so custom formats can implement the same bounds.
+
 ## Custom Formats
 
 Applications can define their own structures by implementing the two traits.
@@ -84,3 +89,38 @@ async fn upload(Multipart(data): Multipart<FormData<'_>>)
 
 These helpers keep parsing logic out of your handlers while remaining
 fully type‑checked.
+
+### Custom CSV example
+
+Implementing a format for CSV values shows how these traits can be
+extended:
+
+```rust,no_run
+use ohkami::format::{FromBody, IntoBody};
+use std::borrow::Cow;
+
+pub struct CSV<T>(pub T);
+
+impl<'r, T: serde::de::DeserializeOwned> FromBody<'r> for CSV<T> {
+    const MIME_TYPE: &'static str = "text/csv";
+
+    fn from_body(body: &'r [u8]) -> Result<Self, impl std::fmt::Display> {
+        let mut rdr = csv::Reader::from_reader(body);
+        let value = rdr.deserialize().next().unwrap()?;
+        Ok(CSV(value))
+    }
+}
+
+impl<T: serde::Serialize> IntoBody for CSV<T> {
+    const CONTENT_TYPE: &'static str = "text/csv";
+
+    fn into_body(self) -> Result<Cow<'static, [u8]>, impl std::fmt::Display> {
+        let mut wtr = csv::Writer::from_writer(Vec::new());
+        wtr.serialize(self.0)?;
+        wtr.flush()?;
+        Ok(Cow::Owned(wtr.into_inner()?))
+    }
+}
+```
+
+This struct can then be used in handlers just like the built‑in types.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ Use these guides when exploring version **0.24**.
 - [MACROS_v0.24.md](MACROS_v0.24.md) — derives plus OpenAPI and Workers macros.
 - [FANGS_v0.24.md](FANGS_v0.24.md) — overview of builtin middleware and
   configuration options.
-- [FORMAT_v0.24.md](FORMAT_v0.24.md) — request/response body helpers.
+- [FORMAT_v0.24.md](FORMAT_v0.24.md) — request/response body helpers and custom format examples.
 - [HEADERS_v0.24.md](HEADERS_v0.24.md) — common header utilities.
 - [DIR_v0.24.md](DIR_v0.24.md) — static directory fang with preloading,
   compression and caching details.


### PR DESCRIPTION
## Summary
- document `format::bound` traits and custom CSV example
- mention new examples in docs/README
- update roadmap with details about the format module
- check off FORMAT_v0.24 in the docs todo list

## Testing
- `awk 'length($0)>100{print NR":"$0}' docs/FORMAT_v0.24.md docs/README.md docs/DOCS_ROADMAP.md docs/DOCS_TODO_v0.24.md`

------
https://chatgpt.com/codex/tasks/task_b_685f1b7561a0832e9f352004060d38a4