### PR TITLE
Improve static file serving example docs

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -45,6 +45,8 @@ including connection trait details.
 - Quick start server documented in [examples/quick_start.md](examples/quick_start.md).
 - JSON serialization illustrated in [examples/json_response.md](examples/json_response.md).
 - Server‑sent events showcased in [examples/sse.md](examples/sse.md).
+- Static file options covered in
+  [examples/static_files.md](examples/static_files.md).
 - `Taskfile.yaml` tasks explained in [TASKS_v0.24](TASKS_v0.24.md) including check, test and bench.
 - Benchmark crates explained in [BENCHES_v0.24](BENCHES_v0.24.md), including lists
   of micro benchmark modules and runtime comparison crates.

--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -54,5 +54,5 @@ Each item should be checked off once the guide has been reviewed against the
 - [ ] Review `examples/multiple-single-threads.md`
 - [x] Review `examples/quick_start.md`
 - [x] Review `examples/sse.md`
-- [ ] Review `examples/static_files.md`
+- [x] Review `examples/static_files.md`
 - [ ] Review `examples/websocket.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,8 @@ Use these guides when exploring version **0.24**.
   - [quick_start.md](examples/quick_start.md) — minimal starter server.
   - [json_response.md](examples/json_response.md) — typed `JSON` wrapper usage.
   - [sse.md](examples/sse.md) — streaming events with `DataStream`.
+  - [static_files.md](examples/static_files.md) — directory serving with
+    compression and caching.
 - [SAMPLES_v0.24.md](SAMPLES_v0.24.md) — overview of the sample projects with Workers templates.
 - [NOTES_FROM_SOURCE_v0.24.md](NOTES_FROM_SOURCE_v0.24.md) — design notes from the source.
 - [../ENV_SETUP.md](../ENV_SETUP.md) — initializing the workspace environment.

--- a/docs/examples/static_files.md
+++ b/docs/examples/static_files.md
@@ -1,22 +1,42 @@
 # Static File Serving
 
-Demonstrates the `Dir` fang for serving files from a directory.  Options enable
-hiding dotfiles, omitting `.html` extensions and using precompressed files when
-available.  Extensive tests cover the behavior under different settings.
+Demonstrates the `Dir` fang for serving files. The example shows how to hide
+dotfiles, omit `.html` extensions and send precompressed versions when the client
+supports them.
 
 ## Files
 
-- `src/main.rs` – configures the `Dir` fang and contains unit tests.
-- `public/` – folder of sample files, some of which have precompressed variants.
+- `src/main.rs` – configures the `Dir` fang and includes unit tests.
+- `public/` – sample files with `.gz` and `.br` variants.
 
 ### `src/main.rs`
 
-`ohkami()` builds an `Ohkami` instance based on provided `Options`.
-The main function simply calls `ohkami(Default::default())` to start a static
-file server on port 3000.
+`ohkami()` builds a server from `Options`:
+
+```rust
+fn ohkami(opts: Options) -> Ohkami {
+    Ohkami::new((
+        "/".Dir("./public")
+            .omit_extensions(if opts.omit_dot_html { &["html"] } else { &[] })
+            .serve_dotfiles(opts.serve_dotfiles)
+            .etag(opts.etag),
+    ))
+}
+```
+
+Running `main` with default options launches on `0.0.0.0:3000`.
+
+Precompressed files such as `sub.js.gz` and `sub.js.br` are preferred depending
+on the `Accept-Encoding` header. If none match and identity is forbidden, the
+server returns **406 Not Acceptable**. The handler also sets `Last-Modified` and
+`ETag` headers so repeated requests can return **304 Not Modified**.
+
+See [`src/main.rs`](../../ohkami-0.24/examples/static_files/src/main.rs) for the
+full code.
 
 ```bash
 $ cargo run --example static_files
 ```
 
-Access files under `public/` such as `/index.html` or `/blog/second.html`.
+Access `public/index.html` at `/` or try `/blog/second.html` to see gzip
+responses.


### PR DESCRIPTION
## Summary
- flesh out `examples/static_files.md` with detail on `Dir` options and caching
- link static files example from the main docs README and roadmap
- mark the todo entry as completed

## Testing
- `awk '{ if(length>100) print NR":"$0 }' docs/examples/static_files.md`
- `awk '{ if(length>100) print NR":"$0 }' docs/README.md`
- `awk '{ if(length>100) print NR":"$0 }' docs/DOCS_ROADMAP.md`


------
https://chatgpt.com/codex/tasks/task_b_685f2129983c832e8517e5b7cada6fa5