### PR TITLE
Document websocket example

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -54,6 +54,8 @@ including connection trait details.
 - Server‑sent events showcased in [examples/sse.md](examples/sse.md).
 - Static file options covered in
   [examples/static_files.md](examples/static_files.md).
+- WebSocket echo patterns described in
+  [examples/websocket.md](examples/websocket.md).
 - `Taskfile.yaml` tasks explained in [TASKS_v0.24](TASKS_v0.24.md) including check, test and bench.
 - Benchmark crates explained in [BENCHES_v0.24](BENCHES_v0.24.md), including lists
   of micro benchmark modules and runtime comparison crates.

--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -55,4 +55,4 @@ Each item should be checked off once the guide has been reviewed against the
 - [x] Review `examples/quick_start.md`
 - [x] Review `examples/sse.md`
 - [x] Review `examples/static_files.md`
-- [ ] Review `examples/websocket.md`
+- [x] Review `examples/websocket.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ Use these guides when exploring version **0.24**.
   - [sse.md](examples/sse.md) — streaming events with `DataStream`.
   - [static_files.md](examples/static_files.md) — directory serving with
     compression and caching.
+  - [websocket.md](examples/websocket.md) — echo patterns and upgrade options.
 - [SAMPLES_v0.24.md](SAMPLES_v0.24.md) — overview of the sample projects with Workers templates.
 - [NOTES_FROM_SOURCE_v0.24.md](NOTES_FROM_SOURCE_v0.24.md) — design notes from the source.
 - [../ENV_SETUP.md](../ENV_SETUP.md) — initializing the workspace environment.

--- a/docs/examples/websocket.md
+++ b/docs/examples/websocket.md
@@ -5,6 +5,10 @@ Several echo servers showcasing different ways to use WebSockets in Ohkami.
 `/echo3` demonstrates splitting the connection.  Static HTML templates are served
 from `template/` for testing with a browser.
 
+The server installs a `Logger` fang and uses the `Dir` fang to serve the
+browser client. Each handler receives a `WebSocketContext` and either upgrades
+the connection or returns a type that does.
+
 ## Files
 
 - `src/main.rs` – contains four echo handlers and mounts the routes.
@@ -18,6 +22,16 @@ Each handler shows a different upgrade pattern:
 - `echo_text_2` – returns a type implementing `IntoResponse` for deferred upgrade.
 - `echo_text_3` – splits the socket and spawns tasks to manage read/write.
 - `echo4` – demonstrates spawning without awaiting the join handle.
+
+```rust,ignore
+Ohkami::new((Logger,
+    "/".Dir("./template").omit_extensions([".html"]),
+    "/echo1".GET(echo_text),
+    "/echo2/:name".GET(echo_text_2),
+    "/echo3/:name".GET(echo_text_3),
+    "/echo4/:name".GET(echo4),
+))
+```
 
 ```bash
 $ cargo run --example websocket


### PR DESCRIPTION
## Summary
- document websocket example
- link from README and roadmap
- check off todo item

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_b_685f277b14d4832e8fdcd540177e59d7