### PR TITLE
Document JWT example

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -51,6 +51,7 @@ including connection trait details.
 - Example projects in `samples/` summarized in [SAMPLES_v0.24](SAMPLES_v0.24.md).
 - Quick start server documented in [examples/quick_start.md](examples/quick_start.md).
 - JSON serialization illustrated in [examples/json_response.md](examples/json_response.md).
+- Token based auth shown in [examples/jwt.md](examples/jwt.md)
 - Server‑sent events showcased in [examples/sse.md](examples/sse.md).
 - Static file options covered in
   [examples/static_files.md](examples/static_files.md).

--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -50,7 +50,7 @@ Each item should be checked off once the guide has been reviewed against the
 - [ ] Review `examples/hello.md`
 - [ ] Review `examples/html_layout.md`
 - [x] Review `examples/json_response.md`
-- [ ] Review `examples/jwt.md`
+- [x] Review `examples/jwt.md`
 - [ ] Review `examples/multiple-single-threads.md`
 - [x] Review `examples/quick_start.md`
 - [x] Review `examples/sse.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,7 @@ Use these guides when exploring version **0.24**.
 - [examples/](examples/README.md) — documentation for the example projects.
   - [quick_start.md](examples/quick_start.md) — minimal starter server.
   - [json_response.md](examples/json_response.md) — typed `JSON` wrapper usage.
+  - [jwt.md](examples/jwt.md) — issuing and validating tokens with the `JWT` fang.
   - [sse.md](examples/sse.md) — streaming events with `DataStream`.
   - [static_files.md](examples/static_files.md) — directory serving with
     compression and caching.

--- a/docs/examples/jwt.md
+++ b/docs/examples/jwt.md
@@ -1,22 +1,25 @@
 # JWT Authentication Example
 
-Generates JSON Web Tokens and secures a private route using the `JWT` fang.
-Set `JWT_SECRET` in `.env` and run the example to obtain a token from `/auth`.
-Use that token in the `Authorization` header to access `/private`.
+Shows how to issue and verify JSON Web Tokens. The secret key is read from
+`JWT_SECRET` using `dotenvy`. `/auth` returns a signed token and `/private`
+requires that token in the `Authorization` header.
 
 ## Files
 
-- `src/main.rs` – issues tokens and verifies them on a private route.
+- `src/main.rs` – issues tokens and validates them on a private route.
 - `.env.sample` – example of the required `JWT_SECRET` variable.
 
 ### `src/main.rs`
 
-- `jwt()` builds the `JWT` fang with the configured secret.
-- `auth` returns a new token from `/auth`.
-- `private` demonstrates extracting the validated payload via `Context`.
+- `jwt()` builds the `JWT` fang with `JWT::default` (HMAC-SHA256).
+- `auth` creates a token with a 24h expiry and a `sub` claim provided by a trait.
+- `private` extracts the verified `JwtPayload` via `Context`.
+
+See the [source](../../ohkami-0.24/examples/jwt/src/main.rs) for details.
 
 ```bash
 $ JWT_SECRET=mysecret cargo run --example jwt
 ```
 
-The included tests show handling large payloads and precompressed files.
+The included test `test_large_jwt` demonstrates issuing a very large payload.
+Run it with `OHKAMI_REQUEST_BUFSIZE=4096` or greater.


### PR DESCRIPTION
## Summary
- expand jwt example usage guide with more details
- link jwt doc from top-level README
- mark jwt example complete in docs roadmap and todo

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685f81444700832ead704d0a19c7444a