### PR TITLE
Document FromRequest example

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -52,6 +52,7 @@ including connection trait details.
 - Quick start server documented in [examples/quick_start.md](examples/quick_start.md).
 - JSON serialization illustrated in [examples/json_response.md](examples/json_response.md).
 - Token based auth shown in [examples/jwt.md](examples/jwt.md)
+- Custom extraction traits in [examples/derive_from_request.md](examples/derive_from_request.md)
 - Server‑sent events showcased in [examples/sse.md](examples/sse.md).
 - Static file options covered in
   [examples/static_files.md](examples/static_files.md).

--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -45,7 +45,7 @@ Each item should be checked off once the guide has been reviewed against the
 - [ ] Review `examples/README.md`
 - [ ] Review `examples/basic_auth.md`
 - [ ] Review `examples/chatgpt.md`
-- [ ] Review `examples/derive_from_request.md`
+- [x] Review `examples/derive_from_request.md`
 - [ ] Review `examples/form.md`
 - [ ] Review `examples/hello.md`
 - [ ] Review `examples/html_layout.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,7 @@ Use these guides when exploring version **0.24**.
   - [quick_start.md](examples/quick_start.md) — minimal starter server.
   - [json_response.md](examples/json_response.md) — typed `JSON` wrapper usage.
   - [jwt.md](examples/jwt.md) — issuing and validating tokens with the `JWT` fang.
+  - [derive_from_request.md](examples/derive_from_request.md) — custom `FromRequest` traits.
   - [sse.md](examples/sse.md) — streaming events with `DataStream`.
   - [static_files.md](examples/static_files.md) — directory serving with
     compression and caching.

--- a/docs/examples/derive_from_request.md
+++ b/docs/examples/derive_from_request.md
@@ -1,20 +1,68 @@
 # Custom `FromRequest` Example
 
-Illustrates implementing the `FromRequest` trait to extract custom types from an
-incoming request.  Four structs demonstrate different patterns for borrowing or
-owning pieces of the request such as the method and path.
+This example demonstrates implementing the [`FromRequest`]
+(../../ohkami-0.24/ohkami/src/request/from_request.rs) trait to pull
+values out of the incoming [`Request`](../../ohkami-0.24/ohkami/src/request/mod.rs).
+It shows a few patterns for borrowing or owning data and how the
+`#[derive(FromRequest)]` macro can compose them.
 
 ## Files
 
-- `src/main.rs` – defines several `FromRequest` implementations.
+- `src/main.rs` – manual and derived `FromRequest` implementations.
 
 ### `src/main.rs`
 
-The example defines wrapper structs (`RequestMethod`, `RequestPath`, etc.) and
-derive macros (`MethodAndPathA`–`D`) showing how to borrow from or own pieces of
-the incoming request. There are no routes; compiling ensures the derives work.
+The example defines small wrappers around the request method and path:
 
-This is a compile‑time demo; run with:
+```rust
+struct RequestMethod(Method);
+impl<'req> FromRequest<'req> for RequestMethod {
+    type Error = std::convert::Infallible;
+    fn from_request(req: &'req Request) -> Option<Result<Self, Self::Error>> {
+        Some(Ok(Self(req.method)))
+    }
+}
+
+struct RequestPath<'req>(std::borrow::Cow<'req, str>);
+impl<'req> FromRequest<'req> for RequestPath<'req> {
+    type Error = std::convert::Infallible;
+    fn from_request(req: &'req Request) -> Option<Result<Self, Self::Error>> {
+        Some(Ok(Self(req.path.str())))
+    }
+}
+
+struct RequestPathOwned(String);
+impl<'req> FromRequest<'req> for RequestPathOwned {
+    type Error = std::convert::Infallible;
+    fn from_request(req: &'req Request) -> Option<Result<Self, Self::Error>> {
+        Some(Ok(Self(req.path.str().into())))
+    }
+}
+```
+
+These are combined into structs using the derive macro:
+
+```rust
+#[derive(FromRequest)]
+struct MethodAndPathA {
+    method: RequestMethod,
+    path:   RequestPathOwned,
+}
+
+#[derive(FromRequest)]
+struct MethodAndPathB<'req> {
+    method: RequestMethod,
+    path:   RequestPath<'req>,
+}
+
+#[derive(FromRequest)]
+struct MethodAndPathC(RequestMethod, RequestPathOwned);
+
+#[derive(FromRequest)]
+struct MethodAndPathD<'req>(RequestMethod, RequestPath<'req>);
+```
+
+No routes are defined – compiling validates the derive logic. Run it with:
 
 ```bash
 $ cargo run --example derive_from_request


### PR DESCRIPTION
## Summary
- expand docs/examples/derive_from_request.md with code snippets
- link the new example from docs/README.md
- add roadmap note for the example
- mark the item complete in DOCS_TODO_v0.24.md

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685f87435d1c832e90aa55a08b97f5e4