### PR TITLE
Document form example

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -53,6 +53,7 @@ including connection trait details.
 - JSON serialization illustrated in [examples/json_response.md](examples/json_response.md).
 - Token based auth shown in [examples/jwt.md](examples/jwt.md)
 - Custom extraction traits in [examples/derive_from_request.md](examples/derive_from_request.md)
+- File uploads demonstrated in [examples/form.md](examples/form.md)
 - Server‑sent events showcased in [examples/sse.md](examples/sse.md).
 - Static file options covered in
   [examples/static_files.md](examples/static_files.md).

--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -46,7 +46,7 @@ Each item should be checked off once the guide has been reviewed against the
 - [ ] Review `examples/basic_auth.md`
 - [ ] Review `examples/chatgpt.md`
 - [x] Review `examples/derive_from_request.md`
-- [ ] Review `examples/form.md`
+- [x] Review `examples/form.md`
 - [ ] Review `examples/hello.md`
 - [ ] Review `examples/html_layout.md`
 - [x] Review `examples/json_response.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ Use these guides when exploring version **0.24**.
   - [json_response.md](examples/json_response.md) — typed `JSON` wrapper usage.
   - [jwt.md](examples/jwt.md) — issuing and validating tokens with the `JWT` fang.
   - [derive_from_request.md](examples/derive_from_request.md) — custom `FromRequest` traits.
+  - [form.md](examples/form.md) — multipart uploads with `Multipart` and `File`.
   - [sse.md](examples/sse.md) — streaming events with `DataStream`.
   - [static_files.md](examples/static_files.md) — directory serving with
     compression and caching.

--- a/docs/examples/form.md
+++ b/docs/examples/form.md
@@ -9,7 +9,21 @@ A simple `Logger` fang prints each request and response for clarity.
 - `src/main.rs` – form handler logic.
 - `form.html` – sample HTML form.
 
+See [`src/main.rs`](../../ohkami-0.24/examples/form/src/main.rs) and
+[`form.html`](../../ohkami-0.24/examples/form/form.html) for the full example.
+
 ### `src/main.rs`
+
+The handler uses the `Multipart` wrapper:
+
+```rust
+#[derive(Deserialize)]
+struct FormData<'req> {
+    #[serde(rename = "account-name")]
+    account_name: Option<&'req str>,
+    pics: Vec<File<'req>>,
+}
+```
 
 - `get_form` returns the HTML form on `/form`.
 - `post_submit` parses a multipart request at `/submit` and logs the result.


### PR DESCRIPTION
## Summary
- document the multipart form example
- link to the example source in README and roadmap
- mark the todo item as complete

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_b_6860117b89d0832e8e40d4520063c2ab