### PR TITLE
Update basic auth example docs

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -52,6 +52,7 @@ including connection trait details.
 - Quick start server documented in [examples/quick_start.md](examples/quick_start.md).
 - JSON serialization illustrated in [examples/json_response.md](examples/json_response.md).
 - Token based auth shown in [examples/jwt.md](examples/jwt.md)
+- HTTP Basic auth covered in [examples/basic_auth.md](examples/basic_auth.md)
 - Custom extraction traits in [examples/derive_from_request.md](examples/derive_from_request.md)
 - File uploads demonstrated in [examples/form.md](examples/form.md)
 - Server‑sent events showcased in [examples/sse.md](examples/sse.md).

--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -43,7 +43,7 @@ Each item should be checked off once the guide has been reviewed against the
 
 ## Examples
 - [ ] Review `examples/README.md`
-- [ ] Review `examples/basic_auth.md`
+- [x] Review `examples/basic_auth.md`
 - [ ] Review `examples/chatgpt.md`
 - [x] Review `examples/derive_from_request.md`
 - [x] Review `examples/form.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@ Use these guides when exploring version **0.24**.
 - [examples/](examples/README.md) — documentation for the example projects.
   - [quick_start.md](examples/quick_start.md) — minimal starter server.
   - [json_response.md](examples/json_response.md) — typed `JSON` wrapper usage.
+  - [basic_auth.md](examples/basic_auth.md) — protecting routes with HTTP Basic authentication.
   - [jwt.md](examples/jwt.md) — issuing and validating tokens with the `JWT` fang.
   - [derive_from_request.md](examples/derive_from_request.md) — custom `FromRequest` traits.
   - [form.md](examples/form.md) — multipart uploads with `Multipart` and `File`.

--- a/docs/examples/basic_auth.md
+++ b/docs/examples/basic_auth.md
@@ -1,26 +1,45 @@
 # Basic Auth Example
 
-This example shows how to protect a route using HTTP Basic authentication.
-
-It creates a nested `Ohkami` instance secured by the `BasicAuth` fang.  The outer
-server exposes a public `/hello` endpoint and a `/private` endpoint that requires
-the configured credentials.
+Demonstrates guarding a nested Ohkami tree with HTTP Basic authentication. A
+`BasicAuth` fang protects the inner application while the outer server keeps a
+public `/hello` route available.
 
 ## Files
 
-- `src/main.rs` – configures a nested `Ohkami` protected by `BasicAuth`.
+- `src/main.rs` – sets up the credentials and routers.
 
 ### `src/main.rs`
 
-`private_ohkami` defines the secured portion with its own route. The outer
-`Ohkami` mounts both the public `/hello` and `/private/hello` which delegates to
-the inner application.
+```rust
+use ohkami::prelude::*;
+use ohkami::fang::BasicAuth;
+
+#[tokio::main]
+async fn main() {
+    let private_ohkami = Ohkami::new((
+        BasicAuth {
+            username: "master of hello",
+            password: "world"
+        },
+        "/hello".GET(|| async {"Hello, private :)"})
+    ));
+
+    Ohkami::new((
+        "/hello".GET(|| async {"Hello, public!"}),
+        "/private".By(private_ohkami)
+    )).howl("localhost:8888").await
+}
+```
+
+See [`src/main.rs`](../../ohkami-0.24/examples/basic_auth/src/main.rs) for the
+full file.
 
 Run it with:
 
 ```bash
-$ cargo run --example basic_auth
+cargo run -p basic_auth
 ```
 
 Then access `http://localhost:8888/hello` for the public route or
-`http://localhost:8888/private/hello` with the credentials `master of hello` / `world`.
+`http://localhost:8888/private/hello` with the credentials `master of hello` /
+`world`. Avoid Basic Auth over plain HTTP; use HTTPS in production.


### PR DESCRIPTION
## Summary
- document Basic Auth example with inline code and HTTPS note
- add Basic Auth entry to README and roadmap
- mark Basic Auth task complete in TODO

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_b_68601438cb08832e814bf7b7a6967086