### PR TITLE
Update startup guide and roadmap

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -17,6 +17,7 @@ It highlights which modules are documented and notes areas that still need work.
   [RESPONSE_v0.24](RESPONSE_v0.24.md) (body helpers and typed statuses).
 - `ohkami/src/typed` â explained in [TYPED_v0.24](TYPED_v0.24.md).
 - `ohkami/src/lib.rs` â crate root documented in the main README.
+- Startup instructions and TLS example covered in [STARTUP_GUIDE_v0.24](STARTUP_GUIDE_v0.24.md).
 - `ohkami/src/lib.rs::prelude` — exports documented in [PRELUDE_v0.24](PRELUDE_v0.24.md)
   with notes on runtime gating.
 - `ohkami/src/ohkami/dir` — static file serving in [DIR_v0.24](DIR_v0.24.md),

--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -33,7 +33,7 @@ Each item should be checked off once the guide has been reviewed against the
 - [x] Review `SAMPLES_v0.24.md`
 - [x] Review `SESSION_v0.24.md`
 - [x] Review `SSE_v0.24.md`
-- [ ] Review `STARTUP_GUIDE_v0.24.md`
+- [x] Review `STARTUP_GUIDE_v0.24.md`
 - [x] Review `TASKS_v0.24.md`
 - [x] Review `TESTING_v0.24.md`
 - [x] Review `TLS_v0.24.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ This directory collects learning material for the
 [Ohkami](https://github.com/ohkami-rs/ohkami) web framework.
 Use these guides when exploring version **0.24**.
 
-- [STARTUP_GUIDE_v0.24.md](STARTUP_GUIDE_v0.24.md) — installation and running your first server.
+- [STARTUP_GUIDE_v0.24.md](STARTUP_GUIDE_v0.24.md) — installation, basic routing and TLS setup.
 - [CODING_GUIDE_v0.24.md](CODING_GUIDE_v0.24.md) — walkthrough of common APIs and patterns.
 - [CODE_STYLE_v0.24.md](CODE_STYLE_v0.24.md) — conventions used throughout the code base.
 - [PRELUDE_v0.24.md](PRELUDE_v0.24.md) — common re‑exports and runtime helpers.

--- a/docs/STARTUP_GUIDE_v0.24.md
+++ b/docs/STARTUP_GUIDE_v0.24.md
@@ -1,10 +1,14 @@
 # Ohkami v0.24 Start-up Guide
 
-This guide walks you through the basics of getting a project running with [Ohkami](https://github.com/ohkami-rs/ohkami) **v0.24**. It focuses on native runtime usage via `tokio`, but the steps are similar for other runtimes.
+This guide walks you through the basics of getting a project running with
+[Ohkami](https://github.com/ohkami-rs/ohkami) **v0.24**.
+It focuses on native runtime usage via `tokio`, but the steps are similar for
+other runtimes.
 
 ## Installation
 
-Add Ohkami to your `Cargo.toml` dependencies. The `rt_tokio` feature enables the async runtime support.
+Add Ohkami to your `Cargo.toml` dependencies.
+The `rt_tokio` feature enables the async runtime support.
 
 ```toml
 [dependencies]
@@ -22,7 +26,8 @@ ohkami = { version = "0.24", features = ["rt_tokio", "tls"] }
 
 ## Hello Ohkami
 
-Below is a minimal HTTP server that exposes two routes. Save this as `src/main.rs` in your Rust project.
+Below is a minimal HTTP server that exposes two routes.
+Save this as `src/main.rs` in your Rust project.
 
 ```rust,no_run
 use ohkami::prelude::*;
@@ -61,14 +66,20 @@ Hello, your_name!
 
 ## Exploring More Features
 
-Ohkami provides optional features for WebSocket, Server‑Sent Events, OpenAPI document generation and more. Enable them in `Cargo.toml` and refer to the README in `ohkami-0.24/` for detailed examples.
+Ohkami provides optional features for WebSocket, Server‑Sent Events and
+automatic OpenAPI documentation.
+Enable them in `Cargo.toml` and refer to the README under `ohkami-0.24/` for
+detailed examples.
 
 ### TLS Example
 
 Create certificate files and run an HTTPS server:
 
 ```bash
-$ openssl req -x509 -newkey rsa:4096 -nodes -keyout server.key -out server.crt -days 365 -subj "/CN=localhost"
+$ openssl req \
+    -x509 -newkey rsa:4096 -nodes \
+    -keyout server.key -out server.crt \
+    -days 365 -subj "/CN=localhost"
 ```
 
 ```rust,no_run
@@ -131,14 +142,18 @@ backends:
 - `OHKAMI_WEBSOCKET_TIMEOUT` – WebSocket timeout in seconds (default **3600**).
 
 Increase these values if your service receives large headers or long‑lived WebSocket connections.
+See [CONFIGURATION_v0.24](CONFIGURATION_v0.24.md) for details on these variables.
 
 ## Why Ohkami?
 
 - **Macro‑less APIs**: Intuitive and type‑safe route definitions.
-- **Multiple runtimes**: Works with `tokio`, `smol`, `nio`, `glommio`, and cloud runtimes like Workers or Lambda.
+- **Multiple runtimes**: Works with `tokio`, `smol`, `nio`, `glommio`, and cloud
+  runtimes like Workers or Lambda.
 - **WebSocket & SSE**: Built‑in asynchronous support.
 - **OpenAPI integration**: Generate API docs automatically.
 - **High performance**: Minimal overhead with convenient testing tools.
 
-Explore the `examples/` directory under `ohkami-0.24` for more usage patterns. Check the main [README](../ohkami-0.24/README.md) for a comprehensive feature list.
+Explore the `examples/` directory under `ohkami-0.24` for more usage patterns.
+Check the main [README](../ohkami-0.24/README.md) for a comprehensive feature
+list.
 


### PR DESCRIPTION
## Summary
- polish `STARTUP_GUIDE_v0.24.md` and keep lines under 100 characters
- mark the guide as reviewed in `DOCS_TODO_v0.24.md`
- mention TLS setup in README
- note the startup guide in the roadmap

## Testing
- `awk 'length($0)>100{print NR, length($0)}' docs/STARTUP_GUIDE_v0.24.md`


------
https://chatgpt.com/codex/tasks/task_b_6860167908c0832e821edc980c83bcd1