### PR TITLE
Document html layout example

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -59,6 +59,7 @@ including connection trait details.
 - Server‑sent events showcased in [examples/sse.md](examples/sse.md).
 - Static file options covered in
   [examples/static_files.md](examples/static_files.md).
+- HTML layout with UIbeam shown in [examples/html_layout.md](examples/html_layout.md).
 - WebSocket echo patterns described in
   [examples/websocket.md](examples/websocket.md).
 - `Taskfile.yaml` tasks explained in [TASKS_v0.24](TASKS_v0.24.md) including check, test and bench.

--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -48,7 +48,7 @@ Each item should be checked off once the guide has been reviewed against the
 - [x] Review `examples/derive_from_request.md`
 - [x] Review `examples/form.md`
 - [ ] Review `examples/hello.md`
-- [ ] Review `examples/html_layout.md`
+- [x] Review `examples/html_layout.md`
 - [x] Review `examples/json_response.md`
 - [x] Review `examples/jwt.md`
 - [ ] Review `examples/multiple-single-threads.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@ Use these guides when exploring version **0.24**.
   - [sse.md](examples/sse.md) — streaming events with `DataStream`.
   - [static_files.md](examples/static_files.md) — directory serving with
     compression and caching.
+  - [html_layout.md](examples/html_layout.md) — wrapping responses with a UIbeam layout.
   - [websocket.md](examples/websocket.md) — echo patterns and upgrade options.
 - [SAMPLES_v0.24.md](SAMPLES_v0.24.md) — overview of the sample projects with Workers templates.
 - [NOTES_FROM_SOURCE_v0.24.md](NOTES_FROM_SOURCE_v0.24.md) — design notes from the source.

--- a/docs/examples/html_layout.md
+++ b/docs/examples/html_layout.md
@@ -1,19 +1,25 @@
 # HTML Layout with UIbeam
 
-Uses the `uibeam` crate to compose a small HTML UI and wrap each response in a
-layout template.  Querying `/?init=5` shows a counter starting at 5 that can be
+This example demonstrates server-side HTML rendering using the
+[`uibeam`](https://crates.io/crates/uibeam) crate.
+A [`Layout`](../../ohkami-0.24/examples/html_layout/src/main.rs#L7-L31)
+fang wraps each response in a page template that loads a Tailwind
+stylesheet from a CDN.
+
+Querying `/?init=5` shows a counter starting at `5` that can be
 incremented or decremented using simple JavaScript.
 
 ## Files
 
-- `src/main.rs` – defines the `Layout` fang and a simple counter component.
+- [`src/main.rs`](../../ohkami-0.24/examples/html_layout/src/main.rs)
+  defines the `Layout` fang and a `Counter` component.
 
-### `src/main.rs`
+### Key Pieces
 
-- `Layout::fang_with_title` wraps HTML responses with a page template.
-- `Counter` is a UIbeam component rendering the interactive counter.
-- `index` handler reads an optional `init` query parameter and returns the
-  rendered page via `HTML`.
+- `Layout::fang_with_title` wraps HTML responses with the template.
+- `Counter` renders the interactive counter UI.
+- `index` reads an optional `init` query parameter and returns the page
+  wrapped in `HTML`.
 
 Run:
 


### PR DESCRIPTION
## Summary
- expand docs/examples/html_layout.md with more detail
- mark html_layout reviewed in DOCS_TODO_v0.24.md
- list html_layout doc in DOCS_ROADMAP.md
- mention html_layout in docs README

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_b_6860193e7bc0832e88e984847950f509