### PR TITLE
Document new bench modules

### DIFF
--- a/docs/BENCHES_v0.24.md
+++ b/docs/BENCHES_v0.24.md
@@ -22,8 +22,12 @@ Micro benchmarks under `benches/benches` cover:
 - `imf_fixdate.rs` — formatting RFC 1123 dates.
 - `itoa.rs` — integer to ASCII conversions.
 - `request_headers.rs` — parsing incoming headers.
+- `response_headers.rs` — inserting and formatting outgoing headers.
+- `tuplemap_vs_hashmap.rs` — comparing custom `TupleMap` lookups to `HashMap`.
 
-Common helpers live in `benches/src`, such as the `header_map.rs` example map.
+Common helpers live in `benches/src`.  Modules implement
+`FxHashMap` wrappers and alternative header containers used by the
+benchmark suites (see `header_map.rs` and `response_headers/`).
 
 Runtime benchmarks live in `benches_rt`:
 

--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -67,8 +67,9 @@ including connection trait details.
 - WebSocket echo patterns described in
   [examples/websocket.md](examples/websocket.md).
 - `Taskfile.yaml` tasks explained in [TASKS_v0.24](TASKS_v0.24.md) including check, test and bench.
-- Benchmark crates explained in [BENCHES_v0.24](BENCHES_v0.24.md), including lists
-  of micro benchmark modules and runtime comparison crates.
+- Benchmark crates explained in [BENCHES_v0.24](BENCHES_v0.24.md) with lists
+  of micro modules (including response header and `TupleMap` benchmarks) and
+  runtime comparison crates.
 - Cargo feature flags detailed in
   [FEATURE_FLAGS_v0.24](FEATURE_FLAGS_v0.24.md) including runtime specific notes.
 - Workspace setup documented in [../ENV_SETUP.md](../ENV_SETUP.md).

--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -7,7 +7,7 @@ Each item should be checked off once the guide has been reviewed against the
 ## Guides
 
 - [ ] Review `ARCHITECTURE_v0.24.md`
-- [ ] Review `BENCHES_v0.24.md`
+- [x] Review `BENCHES_v0.24.md`
 - [x] Review `CODE_STYLE_v0.24.md`
 - [ ] Review `CODING_GUIDE_v0.24.md`
 - [x] Review `CONFIGURATION_v0.24.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,8 @@ Use these guides when exploring version **0.24**.
 - [FEATURE_FLAGS_v0.24.md](FEATURE_FLAGS_v0.24.md) — optional Cargo features
   detailing runtime and protocol flags.
 - [TASKS_v0.24.md](TASKS_v0.24.md) — `task` CLI usage including bench helpers.
-- [BENCHES_v0.24.md](BENCHES_v0.24.md) — micro and runtime benchmarks with tuning tips.
+- [BENCHES_v0.24.md](BENCHES_v0.24.md) — micro and runtime benchmarks with tuning tips,
+  including header container and `TupleMap` comparisons.
 
 - [CONFIGURATION_v0.24.md](CONFIGURATION_v0.24.md) — environment variables and runtime tuning.
 - [DOCS_ROADMAP.md](DOCS_ROADMAP.md) — what parts of the source have been documented so far.


### PR DESCRIPTION
## Summary
- document response header and TupleMap benchmarks
- note new coverage in docs roadmap
- mark BENCHES guide as reviewed
- summarize bench modules in docs README

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_b_686210c232ac832eb7e84fb973b176ca