### PR TITLE
Update chatgpt example docs

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -61,6 +61,8 @@ including connection trait details.
 - Hello world app in [examples/hello.md](examples/hello.md) showing custom
   fangs and typed status
 - Server‑sent events showcased in [examples/sse.md](examples/sse.md).
+- ChatGPT relay example in [examples/chatgpt.md](examples/chatgpt.md) shows
+  `DataStream` with an external API.
 - Static file options covered in
   [examples/static_files.md](examples/static_files.md).
 - HTML layout with UIbeam shown in [examples/html_layout.md](examples/html_layout.md).

--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -44,7 +44,7 @@ Each item should be checked off once the guide has been reviewed against the
 ## Examples
 - [ ] Review `examples/README.md`
 - [x] Review `examples/basic_auth.md`
-- [ ] Review `examples/chatgpt.md`
+- [x] Review `examples/chatgpt.md`
 - [x] Review `examples/derive_from_request.md`
 - [x] Review `examples/form.md`
 - [x] Review `examples/hello.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,7 @@ Use these guides when exploring version **0.24**.
   - [derive_from_request.md](examples/derive_from_request.md) — custom `FromRequest` traits.
   - [form.md](examples/form.md) — multipart uploads with `Multipart` and `File`.
   - [hello.md](examples/hello.md) — starter server with logging and custom headers.
+  - [chatgpt.md](examples/chatgpt.md) — relay ChatGPT responses using SSE.
   - [sse.md](examples/sse.md) — streaming events with `DataStream`.
   - [static_files.md](examples/static_files.md) — directory serving with
     compression and caching.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -6,7 +6,7 @@ how to run it.  If you are new to the framework start with the
 [coding guide](../CODING_GUIDE_v0.24.md) and then explore these examples.
 
 - [basic_auth.md](basic_auth.md)
-- [chatgpt.md](chatgpt.md)
+- [chatgpt.md](chatgpt.md) – relay questions to OpenAI and stream responses with SSE
 - [derive_from_request.md](derive_from_request.md)
 - [form.md](form.md)
 - [hello.md](hello.md)

--- a/docs/examples/chatgpt.md
+++ b/docs/examples/chatgpt.md
@@ -1,16 +1,15 @@
 # ChatGPT Relay Example
 
-Demonstrates using Ohkami to forward client questions to the OpenAI ChatGPT
-API.  It streams responses back to the browser using Server‑Sent Events.
-
-Set an OpenAI API key via the `OPENAI_API_KEY` environment variable or pass
-`-- --api-key <KEY>` when running.
+Demonstrates using Ohkami to forward client questions to the OpenAI ChatGPT API
+and stream the assistant reply with Server‑Sent Events.  Set an API key via the
+`OPENAI_API_KEY` variable or pass `-- --api-key <KEY>` when running.
 
 ```bash
 $ cargo run --example chatgpt -- --api-key <YOUR_KEY>
 ```
 
-POST a message to `/chat-once` and receive streamed chunks in real time.
+POST a plain text message to `/chat-once` and you will receive chunks in real
+time.  The example converts each line from OpenAI into an SSE `DataStream`.
 
 ## Files
 
@@ -22,5 +21,14 @@ POST a message to `/chat-once` and receive streamed chunks in real time.
 ### Flow
 
 1. `APIKey` fang attaches the OpenAI key to each request.
-2. `relay_chat_completion` forwards the request to the OpenAI endpoint and
-   returns a streaming `DataStream` of the response chunks.
+2. `relay_chat_completion` forwards the prompt and converts the streaming
+   response into a `DataStream`.
+
+```rust
+async fn relay_chat_completion(
+    Context(APIKey(key)): Context<'_, APIKey>,
+    Text(prompt): Text<String>,
+) -> Result<DataStream, Error> { /* ... */ }
+```
+
+`DataStream::new` is used internally to push each decoded line to the client.


### PR DESCRIPTION
## Summary
- detail ChatGPT example usage and flow
- list ChatGPT relay in examples index and main docs README
- reference new example in DOCS_ROADMAP
- check off ChatGPT in DOCS_TODO

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_b_68621639be24832e82e935479bc65819