### PR TITLE
Document runtime features and typed headers

### DIFF
--- a/docs/CODING_GUIDE_v0.24.md
+++ b/docs/CODING_GUIDE_v0.24.md
@@ -4,6 +4,17 @@ This guide summarizes the main APIs found in the `ohkami` crate.  It pulls
 together examples from the repository and highlights useful patterns to get
 you productive quickly.
 
+Most applications use one of Ohkami's **runtime features** to select an async
+executor. Enable the feature that matches your environment in `Cargo.toml`:
+
+```toml
+[dependencies]
+ohkami = { version = "0.24", features = ["rt_tokio"] }
+```
+
+Available runtimes include `rt_tokio`, `rt_smol`, `rt_nio`, `rt_glommio`,
+`rt_worker` and `rt_lambda`.
+
 ## Creating an Application
 
 Construct an [`Ohkami`](../ohkami-0.24/ohkami/src/ohkami/mod.rs) by combining
@@ -74,6 +85,23 @@ async fn create() -> status::Created<&'static str> {
     status::Created("done")
 }
 ```
+
+### Typed Headers
+
+Common request and response headers also have typed wrappers under
+[`typed::header`](../ohkami-0.24/ohkami/src/typed/header.rs).
+Handlers can declare headers as parameters to parse them automatically:
+
+```rust
+use ohkami::typed::header::UserAgent;
+
+async fn index(agent: Option<UserAgent>) -> String {
+    format!("request from {agent:?}")
+}
+```
+
+The `ResponseHeaders` type offers setter methods for generating well formed
+headers without manual strings.
 
 ## Testing
 

--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -33,8 +33,8 @@ It highlights which modules are documented and notes areas that still need work.
 
 - `ohkami/src/format` explained in [FORMAT_v0.24](FORMAT_v0.24.md)
   with a custom CSV example.
-- `ohkami/src/header` described in [HEADERS_v0.24](HEADERS_v0.24.md)
-  including parsing helpers and cookie iteration.
+ - `ohkami/src/header` described in [HEADERS_v0.24](HEADERS_v0.24.md)
+   including typed header wrappers, parsing helpers and cookie iteration.
 - `ohkami/src/ws` covered in [WS_v0.24](WS_v0.24.md)
   with `upgrade_durable`, `SessionMap` and split connections.
 

--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -9,7 +9,7 @@ Each item should be checked off once the guide has been reviewed against the
 - [x] Review `ARCHITECTURE_v0.24.md`
 - [x] Review `BENCHES_v0.24.md`
 - [x] Review `CODE_STYLE_v0.24.md`
-- [ ] Review `CODING_GUIDE_v0.24.md`
+- [x] Review `CODING_GUIDE_v0.24.md`
 - [x] Review `CONFIGURATION_v0.24.md`
 - [x] Review `DIR_v0.24.md`
 - [x] Review `DOCS_ROADMAP.md`

--- a/ohkami-0.24/.gitignore
+++ b/ohkami-0.24/.gitignore
@@ -1,3 +1,5 @@
 **/target
 **/Cargo.lock
 /memo.md
+vendor/
+.cargo/


### PR DESCRIPTION
## Summary
- update Coding Guide to mention runtime features
- document typed header usage
- mark Coding Guide review done in TODO
- note typed headers in the roadmap
- ignore vendor and `.cargo` directories

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6862ce52c7b8832eaf26979684d02d86