### PR TITLE
Improve multi-runtime example docs

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -69,6 +69,8 @@ including connection trait details.
 - HTML layout with UIbeam shown in [examples/html_layout.md](examples/html_layout.md).
 - WebSocket echo patterns described in
   [examples/websocket.md](examples/websocket.md).
+- Multiple single-threaded runtimes shown in
+  [examples/multiple-single-threads.md](examples/multiple-single-threads.md).
 - `Taskfile.yaml` tasks explained in [TASKS_v0.24](TASKS_v0.24.md) including check, test and bench.
 - Benchmark crates explained in [BENCHES_v0.24](BENCHES_v0.24.md) with lists
   of micro modules (including response header and `TupleMap` benchmarks) and

--- a/docs/DOCS_TODO_v0.24.md
+++ b/docs/DOCS_TODO_v0.24.md
@@ -51,7 +51,7 @@ Each item should be checked off once the guide has been reviewed against the
 - [x] Review `examples/html_layout.md`
 - [x] Review `examples/json_response.md`
 - [x] Review `examples/jwt.md`
-- [ ] Review `examples/multiple-single-threads.md`
+- [x] Review `examples/multiple-single-threads.md`
 - [x] Review `examples/quick_start.md`
 - [x] Review `examples/sse.md`
 - [x] Review `examples/static_files.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,8 @@ Use these guides when exploring version **0.24**.
   - [basic_auth.md](examples/basic_auth.md) — protecting routes with HTTP Basic authentication.
   - [jwt.md](examples/jwt.md) — issuing and validating tokens with the `JWT` fang.
   - [derive_from_request.md](examples/derive_from_request.md) — custom `FromRequest` traits.
+  - [multiple-single-threads.md](examples/multiple-single-threads.md) — spawn per-core runtimes
+    on a shared port.
   - [form.md](examples/form.md) — multipart uploads with `Multipart` and `File`.
   - [hello.md](examples/hello.md) — starter server with logging and custom headers.
   - [chatgpt.md](examples/chatgpt.md) — relay ChatGPT responses using SSE.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -13,7 +13,7 @@ how to run it.  If you are new to the framework start with the
 - [html_layout.md](html_layout.md)
 - [json_response.md](json_response.md)
 - [jwt.md](jwt.md)
-- [multiple-single-threads.md](multiple-single-threads.md)
+- [multiple-single-threads.md](multiple-single-threads.md) – spawn per-core runtimes on one port
 - [quick_start.md](quick_start.md)
 - [sse.md](sse.md)
 - [static_files.md](static_files.md)

--- a/docs/examples/multiple-single-threads.md
+++ b/docs/examples/multiple-single-threads.md
@@ -1,17 +1,40 @@
 # Multiple Single‑Threaded Runtimes
 
-Starts several single‑threaded Tokio runtimes listening on the same port.
-Useful for scaling CPU‑bound servers without a full multi‑threaded executor.
+This example runs several single‑threaded Tokio runtimes on the same port. It
+scales CPU‑bound services without needing the multi-threaded executor.
+
+Located in [examples/multiple-single-threads](../../ohkami-0.24/examples/multiple-single-threads).
 
 ## Files
 
-- `src/main.rs` – spawns multiple single-threaded Tokio runtimes.
+- `src/main.rs` – sets up the listener and spawns runtimes per CPU core.
 
 ### `src/main.rs`
 
-`ohkami()` defines a tiny app with one route. The `main` function builds a TCP
-listener with port reuse enabled and then starts several runtimes, each calling
-`serve()` to accept connections on the same port.
+`main` creates a `TcpSocket` with port reuse enabled. It launches a new thread
+for each extra CPU core, each running a single-threaded runtime. Every runtime
+calls `serve()` which binds to `0.0.0.0:8000` and passes the listener to
+`Ohkami::howl`.
+
+```rust
+async fn serve(o: Ohkami) -> std::io::Result<()> {
+    let socket = tokio::net::TcpSocket::new_v4()?;
+    socket.set_reuseport(true)?;
+    socket.set_reuseaddr(true)?;
+    socket.set_nodelay(true)?;
+    socket.bind("0.0.0.0:8000".parse().unwrap())?;
+    let listener = socket.listen(1024)?;
+    o.howl(listener).await;
+    Ok(())
+}
+
+for _ in 0..(num_cpus::get() - 1) {
+    std::thread::spawn(|| {
+        runtime().block_on(serve(ohkami())).expect("serving error");
+    });
+}
+runtime().block_on(serve(ohkami())).expect("serving error");
+```
 
 ```bash
 $ cargo run --example multiple-single-threads


### PR DESCRIPTION
## Summary
- flesh out multiple-single-threads example documentation
- list the example in the docs README files
- mark the example complete in the docs TODO checklist
- reference the example in the docs roadmap

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6862d94d787c832e82da4464c51aa30d