### PR TITLE
Document Lambda WebSocket adapter

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -97,7 +97,9 @@ Additional gaps:
 - More real-world taskfile usage examples would help new contributors.
 - Utility modules `ohkami_lib::stream`, `slice`, `time` and `num` are now covered
   in [UTILS_v0.24](UTILS_v0.24.md).
-- The AWS Lambda WebSocket adapter remains unfinished and lacks documentation.
+- The AWS Lambda WebSocket adapter is partially implemented and now documented
+  in [RUNTIME_ADAPTERS_v0.24](RUNTIME_ADAPTERS_v0.24.md), though the request and
+  response mapping layer is still a work in progress.
 - Outstanding ideas and missing features are summarized in
   [FEATURE_REQUESTS.md](FEATURE_REQUESTS.md).
 - Each guide should be audited for accuracy. See

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ For a quick project overview, see the main
 - [SESSION_v0.24.md](SESSION_v0.24.md) — how connections are managed,
   including the `Connection` trait and timeout control.
 - [RUNTIME_ADAPTERS_v0.24.md](RUNTIME_ADAPTERS_v0.24.md) — deploying to
-  Workers or Lambda with examples.
+  Workers or Lambda with examples, including Lambda WebSocket support.
 - [UTILS_v0.24.md](UTILS_v0.24.md) — helper functions and utility crate (stream,
   slice, num and time modules).
 - [MACROS_v0.24.md](MACROS_v0.24.md) — derives plus OpenAPI and Workers macros.

--- a/docs/RUNTIME_ADAPTERS_v0.24.md
+++ b/docs/RUNTIME_ADAPTERS_v0.24.md
@@ -50,9 +50,28 @@ async fn main() -> Result<(), lambda_runtime::Error> {
 ```
 
 With the `ws` feature enabled you can handle API Gateway WebSocket events using
-`LambdaWebSocket::handle`.
-An adapter to map between Lambda events and Ohkami `Request`/`Response` types is
-planned but not yet finalized.
+`LambdaWebSocket::handle`. This helper adapts an async function into a
+`lambda_runtime::Service` that receives a `LambdaWebSocket` instance. The type
+wraps the connection context and exposes `send` and `close` methods.
+
+```rust,no_run
+use ohkami::{LambdaWebSocket, LambdaWebSocketMESSAGE};
+use lambda_runtime::Error;
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    lambda_runtime::run(LambdaWebSocket::handle(echo)).await
+}
+
+async fn echo(mut ws: LambdaWebSocket<LambdaWebSocketMESSAGE>) -> Result<(), Error> {
+    ws.send(ws.event).await?;
+    ws.close().await?;
+    Ok(())
+}
+```
+
+An adapter to map between generic Lambda events and Ohkami `Request`/`Response`
+types is still planned but not yet finalized.
 
 These modules let you deploy the same application logic to native servers or
 serverless platforms with minimal changes.


### PR DESCRIPTION
## Summary
- expand `RUNTIME_ADAPTERS_v0.24.md` with example usage of `LambdaWebSocket::handle`
- highlight Lambda WebSocket support in docs README
- update roadmap noting new documentation

## Testing
- `git diff --cached --name-status`


------
https://chatgpt.com/codex/tasks/task_b_686302938fb4832e93d68317bd053788