### PR TITLE
Expand header documentation

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -17,7 +17,8 @@ It highlights which modules are documented and notes areas that still need work.
   [RESPONSE_v0.24](RESPONSE_v0.24.md) (body helpers and typed statuses).
 - `ohkami/src/typed` â explained in [TYPED_v0.24](TYPED_v0.24.md).
 - `ohkami/src/lib.rs` â crate root documented in the main README.
-- `docs/README.md` links back to the crate README so readers can quickly reach the latest quick start.
+- `docs/README.md` points back to the crate README so new users can quickly reach
+  the latest quick start.
 - Module layout overviewed in [ARCHITECTURE_v0.24](ARCHITECTURE_v0.24.md).
 - Startup instructions and TLS example covered in [STARTUP_GUIDE_v0.24](STARTUP_GUIDE_v0.24.md).
 - `ohkami/src/lib.rs::prelude` — exports documented in [PRELUDE_v0.24](PRELUDE_v0.24.md)
@@ -37,7 +38,8 @@ It highlights which modules are documented and notes areas that still need work.
 - `ohkami/src/format` explained in [FORMAT_v0.24](FORMAT_v0.24.md)
   with a custom CSV example.
  - `ohkami/src/header` described in [HEADERS_v0.24](HEADERS_v0.24.md)
-   including typed header wrappers, parsing helpers and cookie iteration.
+   including typed header wrappers, parsing helpers, cookie iteration and
+   precompressed file detection.
 - `ohkami/src/ws` covered in [WS_v0.24](WS_v0.24.md)
   with `upgrade_durable`, `SessionMap` and split connections.
 

--- a/docs/HEADERS_v0.24.md
+++ b/docs/HEADERS_v0.24.md
@@ -48,10 +48,17 @@ negotiate compressed responses.
 The helper `QValue::parse` converts a quality string like `"0.8"` into a sortable
 floating point representation.
 
-Typed helpers exist for many common headers.  For example `ResponseHeaders` has
-methods like `ContentType` and `CacheControl` which accept strongly typed
-wrappers.  Implement `FromHeader` for your own types to parse custom headers on
-incoming requests.
+Typed helpers exist for many common headers.  For example `ResponseHeaders`
+provides methods like `ContentType` and `CacheControl` which accept strongly
+typed wrappers.  Implement `FromHeader` for your own types to parse custom
+headers on incoming requests.
+
+### Precompressed Files
+
+`CompressionEncoding::from_file_path` detects algorithms from file extensions.
+It returns the remaining path with extensions removed so pre-compressed assets
+like `app.js.gz.br` can be served with the correct `Content-Encoding` header.
+`Dir` uses this helper to look up files preferred by `Accept-Encoding`.
 
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,8 @@ For a quick project overview, see the main
 - [FANGS_v0.24.md](FANGS_v0.24.md) — overview of builtin middleware and
   configuration options.
 - [FORMAT_v0.24.md](FORMAT_v0.24.md) — request/response body helpers and custom format examples.
-- [HEADERS_v0.24.md](HEADERS_v0.24.md) — common header utilities.
+- [HEADERS_v0.24.md](HEADERS_v0.24.md) — common header utilities with `QValue`
+  and compression helpers.
 - [DIR_v0.24.md](DIR_v0.24.md) — static directory fang with preloading,
   compression and caching details.
 - [REQUEST_v0.24.md](REQUEST_v0.24.md) — request structure, context store and extraction.


### PR DESCRIPTION
## Summary
- document `CompressionEncoding::from_file_path` in header guide
- mention header compression helpers in docs README
- update docs roadmap with note about precompressed file detection

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_b_6864610834c4832e9e82ad8df5fa9b5e