### PR TITLE
Improve UTILS docs

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -99,7 +99,7 @@ Additional gaps:
   missing.
 - More real-world taskfile usage examples would help new contributors.
 - Utility modules `ohkami_lib::stream`, `slice`, `time` and `num` are now covered
-  in [UTILS_v0.24](UTILS_v0.24.md).
+  in [UTILS_v0.24](UTILS_v0.24.md) with a queue streaming example.
 - The AWS Lambda WebSocket adapter is partially implemented and now documented
   in [RUNTIME_ADAPTERS_v0.24](RUNTIME_ADAPTERS_v0.24.md), though the request and
   response mapping layer is still a work in progress.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,8 +18,8 @@ For a quick project overview, see the main
   including the `Connection` trait and timeout control.
 - [RUNTIME_ADAPTERS_v0.24.md](RUNTIME_ADAPTERS_v0.24.md) — deploying to
   Workers or Lambda with examples, including Lambda WebSocket support.
-- [UTILS_v0.24.md](UTILS_v0.24.md) — helper functions and utility crate (stream,
-  slice, num and time modules).
+- [UTILS_v0.24.md](UTILS_v0.24.md) — helper functions with `stream::queue` example
+  and slice, num and time modules.
 - [MACROS_v0.24.md](MACROS_v0.24.md) — derives plus OpenAPI and Workers macros.
 - [FANGS_v0.24.md](FANGS_v0.24.md) — overview of builtin middleware and
   configuration options.

--- a/docs/UTILS_v0.24.md
+++ b/docs/UTILS_v0.24.md
@@ -47,3 +47,27 @@ These helpers keep Ohkami lightweight while avoiding extra dependencies in user 
 - `slice` and `CowSlice` – manual byte slice types for zero-copy operations.
 - `num` – `itoa` and `hexized` for efficient number formatting.
 - `time` – `imf_fixdate` to produce RFC 9110 date strings.
+
+### Stream Queue Example
+
+The `stream` module includes a `queue` helper which spawns an async task pushing
+items into a buffer. The resulting stream can be combined with SSE or other
+code using `StreamExt` methods.
+
+```rust,no_run
+use ohkami::sse::DataStream;
+use ohkami::util::{stream, StreamExt};
+use tokio::time::{sleep, Duration};
+
+async fn events() -> DataStream {
+    DataStream::from(stream::queue(|mut q| async move {
+        for i in 0..3 {
+            sleep(Duration::from_secs(1)).await;
+            q.push(format!("tick {i}"));
+        }
+    }))
+}
+```
+
+See [`ohkami_lib/src/stream.rs`](../ohkami-0.24/ohkami_lib/src/stream.rs) for
+implementation details.


### PR DESCRIPTION
## Summary
- document `stream::queue` helper in `UTILS_v0.24.md`
- mention new queue example in docs index
- note queue example in documentation roadmap

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_b_6864651bbcd0832eada8a23e9901a565