### PR TITLE
Update docs for bindings macro

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -47,12 +47,12 @@ It highlights which modules are documented and notes areas that still need work.
 including connection trait details.
 - Cloud runtime adapters (`x_worker`, `x_lambda`) documented in
   [RUNTIME_ADAPTERS_v0.24](RUNTIME_ADAPTERS_v0.24.md) now include
-  examples for `#[bindings]` and Lambda WebSocket handling.
+  examples for `#[bindings]` (with env selection) and Lambda WebSocket handling.
 - `util` helpers and the `ohkami_lib` crate covered in [UTILS_v0.24](UTILS_v0.24.md).
 - Error conversions via `IntoResponse` documented in
   [ERROR_HANDLING_v0.24](ERROR_HANDLING_v0.24.md).
 - Procedural macros in [MACROS_v0.24](MACROS_v0.24.md) now include examples for
-  `#[operation]`, `#[worker]` and `#[bindings]`.
+  `#[operation]`, `#[worker]` and `#[bindings(env)]`.
 - `ohkami_openapi` documented in [OPENAPI_v0.24](OPENAPI_v0.24.md) with examples
   for `openapi::Tag` and custom `#[openapi::operation]` overrides.
 - Dependency injection, typed error handling and custom path parameter parsing now covered in

--- a/docs/MACROS_v0.24.md
+++ b/docs/MACROS_v0.24.md
@@ -55,6 +55,18 @@ objects. These rely on the `worker` runtime crate.
 environment bindings.  This removes boilerplate when accessing KV stores or other
 resources from Workers code.
 
+Pass an environment name such as `dev` to load bindings from that section of the
+configuration:
+
+```rust
+#[ohkami::bindings(dev)]
+struct DevBindings;
+```
+
+The generated struct implements `FromRequest` and exposes constants for any
+`vars` values so you can pull the bindings from a worker `Env` or use them
+directly.
+
 ```rust
 #[ohkami::bindings]
 struct Bindings;

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,8 @@ For a quick project overview, see the main
   Workers or Lambda with examples, including Lambda WebSocket support.
 - [UTILS_v0.24.md](UTILS_v0.24.md) — helper functions with `stream::queue` example
   and slice, num and time modules.
-- [MACROS_v0.24.md](MACROS_v0.24.md) — derives plus OpenAPI and Workers macros.
+- [MACROS_v0.24.md](MACROS_v0.24.md) — derives plus OpenAPI and Workers macros
+  including `#[bindings(env)]` for environment specific bindings.
 - [FANGS_v0.24.md](FANGS_v0.24.md) — overview of builtin middleware and
   configuration options.
 - [FORMAT_v0.24.md](FORMAT_v0.24.md) — request/response body helpers and custom format examples.

--- a/docs/RUNTIME_ADAPTERS_v0.24.md
+++ b/docs/RUNTIME_ADAPTERS_v0.24.md
@@ -31,6 +31,17 @@ async fn app() -> ohkami::Ohkami {
 }
 ```
 
+Add an environment name like `dev` to pull bindings from that section of your
+configuration:
+
+```rust
+#[ohkami::bindings(dev)]
+struct DevBindings;
+```
+
+The generated struct implements `FromRequest` so handlers can receive it
+directly.
+
 See the inline examples in `x_worker.rs` for a full setup.
 
 ## AWS Lambda


### PR DESCRIPTION
## Summary
- document `#[bindings(env)]` usage in the macros guide
- show environment selection in runtime adapter docs
- mention env support in README index and roadmap

## Testing
- `grep -n "\(.\{101\}\)" -n docs/MACROS_v0.24.md`
- `grep -n "\(.\{101\}\)" -n docs/RUNTIME_ADAPTERS_v0.24.md`


------
https://chatgpt.com/codex/tasks/task_b_686488f97ae0832e8c00995934923493