### PR TITLE
Add Lambda WebSocket guide

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -41,7 +41,8 @@ It highlights which modules are documented and notes areas that still need work.
    including typed header wrappers, parsing helpers, cookie iteration and
    precompressed file detection.
 - `ohkami/src/ws` covered in [WS_v0.24](WS_v0.24.md)
-  with `upgrade_durable`, `SessionMap` and split connections.
+  with `upgrade_durable`, `SessionMap`, split connections
+  and the `LambdaWebSocket` helper for API Gateway.
 
 - `ohkami/src/session` - lifecycle explained in [SESSION_v0.24](SESSION_v0.24.md)
 including connection trait details.

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,8 @@ For a quick project overview, see the main
   automatic OpenAPI documentation.
 - [TLS_v0.24.md](TLS_v0.24.md) — HTTPS support via `rustls` using `howls`.
 - [TESTING_v0.24.md](TESTING_v0.24.md) — debug-only in-memory harness for calling routes.
-- [WS_v0.24.md](WS_v0.24.md) — upgrading connections to WebSockets and Workers.
+- [WS_v0.24.md](WS_v0.24.md) — upgrading connections to WebSockets with
+  Workers and Lambda adapters.
 - [SSE_v0.24.md](SSE_v0.24.md) — streaming Server‑Sent Events with the
   `DataStream` queue and custom `Data` types.
 - [ROUTER_v0.24.md](ROUTER_v0.24.md) — how routes are organized and finalized.

--- a/docs/WS_v0.24.md
+++ b/docs/WS_v0.24.md
@@ -12,6 +12,33 @@ async fn handler(ctx: WebSocketContext<'_>) -> WebSocket {
 }
 ```
 
+### AWS Lambda
+
+When compiled with the `rt_lambda` feature Ohkami exposes a
+`LambdaWebSocket` type for handling API Gateway WebSocket events.
+Use `LambdaWebSocket::handle` to adapt an async function into a
+`lambda_runtime::Service`:
+
+```rust,no_run
+use ohkami::{LambdaWebSocket, LambdaWebSocketMESSAGE};
+use lambda_runtime::Error;
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    lambda_runtime::run(LambdaWebSocket::handle(echo)).await
+}
+
+async fn echo(mut ws: LambdaWebSocket<LambdaWebSocketMESSAGE>) -> Result<(), Error> {
+    ws.send(ws.event).await?;
+    ws.close().await?;
+    Ok(())
+}
+```
+
+See [`x_lambda.rs`](../ohkami-0.24/ohkami/src/x_lambda.rs) for details on the
+implementation and client used to send responses back through the management
+API.
+
 Handlers receive a context extracted from the request. Calling `.upgrade` or
 `.upgrade_with` returns a `WebSocket` response that completes the handshake and
 runs the provided async closure.


### PR DESCRIPTION
## Summary
- mention Lambda adapters in docs README
- document LambdaWebSocket usage in `WS_v0.24.md`
- note LambdaWebSocket helper in DOCS_ROADMAP

## Testing
- `awk 'length($0)>100{print NR":"$0}' docs/WS_v0.24.md`
- `awk 'length($0)>100{print NR":"$0}' docs/README.md`
- `awk 'length($0)>100{print NR":"$0}' docs/DOCS_ROADMAP.md`


------
https://chatgpt.com/codex/tasks/task_b_68649b80f9e4832e9823f08777f2ec82