### PR TITLE
Document SetCookie parsing helpers

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -38,7 +38,7 @@ It highlights which modules are documented and notes areas that still need work.
 - `ohkami/src/format` explained in [FORMAT_v0.24](FORMAT_v0.24.md)
   with a custom CSV example.
  - `ohkami/src/header` described in [HEADERS_v0.24](HEADERS_v0.24.md)
-   including typed header wrappers, parsing helpers, cookie iteration and
+   including typed header wrappers, `SetCookie::from_raw`, cookie iteration and
    precompressed file detection.
 - `ohkami/src/ws` covered in [WS_v0.24](WS_v0.24.md)
   with `upgrade_durable`, `SessionMap`, split connections

--- a/docs/HEADERS_v0.24.md
+++ b/docs/HEADERS_v0.24.md
@@ -34,6 +34,18 @@ for c in res.headers.SetCookie() {
 }
 ```
 
+Each item is parsed with `SetCookie::from_raw` so invalid directives are ignored
+in debug builds with a warning. You can also parse a single header manually:
+
+```rust
+use ohkami::header::SetCookie;
+
+let raw = "user=xyz; HttpOnly; Max-Age=30";
+let sc = SetCookie::from_raw(raw)?;
+assert_eq!(sc.MaxAge(), Some(30));
+```
+
+
 ## Entity Tags
 `ETag` parses strong and weak entity tags.  Use `ETag::parse` or the iterator
 helpers to process conditional request headers.

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ For a quick project overview, see the main
   configuration options.
 - [FORMAT_v0.24.md](FORMAT_v0.24.md) — request/response body helpers and custom format examples.
 - [HEADERS_v0.24.md](HEADERS_v0.24.md) — common header utilities with `QValue`
-  and compression helpers.
+  and compression helpers plus `SetCookie` parsing.
 - [DIR_v0.24.md](DIR_v0.24.md) — static directory fang with preloading,
   compression and caching details.
 - [REQUEST_v0.24.md](REQUEST_v0.24.md) — request structure, context store and extraction.


### PR DESCRIPTION
## Summary
- highlight `SetCookie::from_raw` in HEADERS guide
- mention the new example in docs README
- update DOCS_ROADMAP entry for header utilities

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6864ad7d2f64832e9cf8346f508c9266