### PR TITLE
Improve utils guide

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -49,7 +49,8 @@ including connection trait details.
 - Cloud runtime adapters (`x_worker`, `x_lambda`) documented in
   [RUNTIME_ADAPTERS_v0.24](RUNTIME_ADAPTERS_v0.24.md) now include
   examples for `#[bindings]` (with env selection) and Lambda WebSocket handling.
-- `util` helpers and the `ohkami_lib` crate covered in [UTILS_v0.24](UTILS_v0.24.md).
+- `util` helpers and the `ohkami_lib` crate covered in [UTILS_v0.24](UTILS_v0.24.md)
+  now document base64 utilities, cookie parsing, `timeout_in` and a stream queue example.
 - Error conversions via `IntoResponse` documented in
   [ERROR_HANDLING_v0.24](ERROR_HANDLING_v0.24.md).
 - Procedural macros in [MACROS_v0.24](MACROS_v0.24.md) now include examples for
@@ -99,8 +100,8 @@ Additional gaps:
 - Benchmarking basics are documented but real performance numbers are still
   missing.
 - More real-world taskfile usage examples would help new contributors.
-- Utility modules `ohkami_lib::stream`, `slice`, `time` and `num` are now covered
-  in [UTILS_v0.24](UTILS_v0.24.md) with a queue streaming example.
+  - Utility modules `ohkami_lib::stream`, `slice`, `time` and `num` are now covered
+    in [UTILS_v0.24](UTILS_v0.24.md) with a queue streaming example and timeout usage.
 - The AWS Lambda WebSocket adapter is partially implemented and now documented
   in [RUNTIME_ADAPTERS_v0.24](RUNTIME_ADAPTERS_v0.24.md), though the request and
   response mapping layer is still a work in progress.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,8 +18,9 @@ For a quick project overview, see the main
   including the `Connection` trait and timeout control.
 - [RUNTIME_ADAPTERS_v0.24.md](RUNTIME_ADAPTERS_v0.24.md) — deploying to
   Workers or Lambda with examples, including Lambda WebSocket support.
-- [UTILS_v0.24.md](UTILS_v0.24.md) — helper functions with `stream::queue` example
-  and slice, num and time modules.
+- [UTILS_v0.24.md](UTILS_v0.24.md) — helper functions such as base64 utilities,
+  cookie parsing, `timeout_in` and the `stream::queue` example covering slice,
+  num and time modules.
 - [MACROS_v0.24.md](MACROS_v0.24.md) — derives plus OpenAPI and Workers macros
   including `#[bindings(env)]` for environment specific bindings.
 - [FANGS_v0.24.md](FANGS_v0.24.md) — overview of builtin middleware and

--- a/docs/UTILS_v0.24.md
+++ b/docs/UTILS_v0.24.md
@@ -17,10 +17,33 @@ helpers and a small async stream adapter.
 
 ## Data Utilities
 
-- Base64 helpers: `base64_encode`, `base64_decode`, and URL‑safe variants.
+- Base64 helpers: `base64_encode`, `base64_decode`, `base64_decode_utf8` and
+  URL‑safe `base64_url_encode`/`base64_url_decode`.
 - `iter_cookies` parses a raw `Cookie` header into `(name, value)` pairs.
-- `unix_timestamp` returns the current Unix time and works in both native and worker environments.
+- Example:
+```rust
+let mut it = ohkami::util::iter_cookies(
+    "PHPSESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43"
+);
+assert_eq!(it.next(), Some(("PHPSESSID", "298zf09hf012fh2")));
+assert_eq!(it.next(), Some(("csrftoken", "u32t4o3tb3gg43")));
+assert_eq!(it.next(), None);
+```
+- `unix_timestamp` returns the current Unix time and works in both native and
+  worker environments.
 - `timeout_in` wraps a future with a timeout when using native runtimes.
+```rust,no_run
+use std::time::Duration;
+
+let result = ohkami::util::timeout_in(Duration::from_secs(1), async {
+    slow_operation().await
+}).await;
+if let Some(v) = result {
+    println!("finished: {v}");
+} else {
+    println!("timed out");
+}
+```
 - `percent_encode`, `percent_decode` and `percent_decode_utf8` provide basic URL
   encoding helpers used throughout the framework.
 


### PR DESCRIPTION
## Summary
- expand `UTILS_v0.24.md` with base64, cookie and timeout examples
- mention these updates in `DOCS_ROADMAP.md`
- clarify `UTILS_v0.24.md` description in `docs/README.md`

## Testing
- `awk 'length($0)>100 {print NR, length($0)}' docs/UTILS_v0.24.md`
- `awk 'length($0)>100 {print NR, length($0)}' docs/DOCS_ROADMAP.md`
- `awk 'length($0)>100 {print NR, length($0)}' docs/README.md`

------
https://chatgpt.com/codex/tasks/task_b_6864aeddba38832e95cb3c1ef57ebc37