### PR TITLE
Improve SetCookie builder docs

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -37,9 +37,9 @@ It highlights which modules are documented and notes areas that still need work.
 
 - `ohkami/src/format` explained in [FORMAT_v0.24](FORMAT_v0.24.md)
   with a custom CSV example.
- - `ohkami/src/header` described in [HEADERS_v0.24](HEADERS_v0.24.md)
-   including typed header wrappers, `SetCookie::from_raw`, cookie iteration and
-   precompressed file detection.
+- `ohkami/src/header` described in [HEADERS_v0.24](HEADERS_v0.24.md)
+  including typed header wrappers, `SetCookie` builder methods and parsing,
+  cookie iteration and precompressed file detection.
 - `ohkami/src/ws` covered in [WS_v0.24](WS_v0.24.md)
   with `upgrade_durable`, `SessionMap`, split connections
   and the `LambdaWebSocket` helper for API Gateway.

--- a/docs/HEADERS_v0.24.md
+++ b/docs/HEADERS_v0.24.md
@@ -20,8 +20,15 @@ The same helper can be used with typed headers such as
 ## Cookie Builder
 
 `SetCookie` exposes a builder style API for generating `Set-Cookie` headers.
-All attributes like `MaxAge`, `Domain`, `Secure` and `SameSite` are optional and
-can be chained.
+All attributes are optional and the methods return the builder so calls can be
+chained.  Available helpers include:
+
+- `Expires(datetime)` – absolute expiry as a string, e.g. from
+  `ohkami::util::imf_fixdate`.
+- `MaxAge(seconds)` – relative lifetime in seconds.
+- `Domain(domain)` and `Path(path)` – scope the cookie.
+- `Secure()` and `HttpOnly()` – toggle those flags.
+- `SameSiteLax()`, `SameSiteNone()` and `SameSiteStrict()`.
 
 ```rust
 res.headers.set().SetCookie("id", "42", |c| c.Path("/").SameSiteLax());

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ For a quick project overview, see the main
   configuration options.
 - [FORMAT_v0.24.md](FORMAT_v0.24.md) — request/response body helpers and custom format examples.
 - [HEADERS_v0.24.md](HEADERS_v0.24.md) — common header utilities with `QValue`
-  and compression helpers plus `SetCookie` parsing.
+  and compression helpers plus `SetCookie` parsing and builder methods.
 - [DIR_v0.24.md](DIR_v0.24.md) — static directory fang with preloading,
   compression and caching details.
 - [REQUEST_v0.24.md](REQUEST_v0.24.md) — request structure, context store and extraction.


### PR DESCRIPTION
## Summary
- document SetCookie builder methods in the headers guide
- mention builder coverage in docs README
- update roadmap with note about builder methods

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6864b180a6fc832ea5aa9ef9d13c989d