### PR TITLE
Add Lambda section to websocket example

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -76,7 +76,8 @@ including connection trait details.
   [examples/static_files.md](examples/static_files.md).
 - HTML layout with UIbeam shown in [examples/html_layout.md](examples/html_layout.md).
 - WebSocket echo patterns described in
-  [examples/websocket.md](examples/websocket.md).
+  [examples/websocket.md](examples/websocket.md) now include a Lambda
+  adapter example using `LambdaWebSocket::handle`.
 - Multiple single-threaded runtimes shown in
   [examples/multiple-single-threads.md](examples/multiple-single-threads.md).
 - `Taskfile.yaml` tasks explained in [TASKS_v0.24](TASKS_v0.24.md) including check, test and bench.

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,7 +69,8 @@ For a quick project overview, see the main
   - [static_files.md](examples/static_files.md) — directory serving with
     compression and caching.
   - [html_layout.md](examples/html_layout.md) — wrapping responses with a UIbeam layout.
-  - [websocket.md](examples/websocket.md) — echo patterns and upgrade options.
+  - [websocket.md](examples/websocket.md) — echo patterns, connection splitting
+    and Lambda integration.
 - [SAMPLES_v0.24.md](SAMPLES_v0.24.md) — overview of the sample projects with Workers templates.
 - [NOTES_FROM_SOURCE_v0.24.md](NOTES_FROM_SOURCE_v0.24.md) - design notes: router and Dir.
 - [../ENV_SETUP.md](../ENV_SETUP.md) — initializing the workspace environment.

--- a/docs/examples/websocket.md
+++ b/docs/examples/websocket.md
@@ -36,3 +36,29 @@ Ohkami::new((Logger,
 ```bash
 $ cargo run --example websocket
 ```
+
+## AWS Lambda
+
+Ohkami can also handle API Gateway WebSocket events using `LambdaWebSocket`.
+Compile with the `rt_lambda` and `ws` features and pass a handler to
+`LambdaWebSocket::handle`:
+
+```rust,no_run
+use ohkami::{LambdaWebSocket, LambdaWebSocketMESSAGE};
+
+#[ohkami::lambda]
+async fn main() -> Result<(), lambda_runtime::Error> {
+    lambda_runtime::run(LambdaWebSocket::handle(echo)).await
+}
+
+async fn echo(
+    mut ws: LambdaWebSocket<LambdaWebSocketMESSAGE>
+) -> Result<(), lambda_runtime::Error> {
+    ws.send(ws.event).await?;
+    ws.close().await?;
+    Ok(())
+}
+```
+
+Implementation details live in
+[`x_lambda.rs`](../../ohkami-0.24/ohkami/src/x_lambda.rs).


### PR DESCRIPTION
## Summary
- document AWS Lambda usage in `examples/websocket.md`
- reference the Lambda integration from README
- update DOCS_ROADMAP to note the new example coverage

## Testing
- `cargo check --quiet`

------
https://chatgpt.com/codex/tasks/task_b_6864b48547d4832e89f58f2b4e64cfaa