### PR TITLE
Update TLS doc with config example

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -11,7 +11,7 @@ It highlights which modules are documented and notes areas that still need work.
   [CODING_GUIDE_v0.24](CODING_GUIDE_v0.24.md) and
   [PATTERNS_v0.24](PATTERNS_v0.24.md).
 - `ohkami/src/testing` — explained in [TESTING_v0.24](TESTING_v0.24.md).
-- `ohkami/src/tls` — usage documented in [TLS_v0.24](TLS_v0.24.md).
+- `ohkami/src/tls` — usage documented in [TLS_v0.24](TLS_v0.24.md) with certificate loading example.
 - `ohkami/src/request` and `ohkami/src/response` - detailed in
   [REQUEST_v0.24](REQUEST_v0.24.md) (context store and payload limits) and
   [RESPONSE_v0.24](RESPONSE_v0.24.md) (body helpers and typed statuses).

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,8 @@ For a quick project overview, see the main
 - [TYPED_v0.24.md](TYPED_v0.24.md) — typed statuses and headers.
 - [OPENAPI_v0.24.md](OPENAPI_v0.24.md) — macros and `Ohkami::generate` for
   automatic OpenAPI documentation.
-- [TLS_v0.24.md](TLS_v0.24.md) — HTTPS support via `rustls` using `howls`.
+- [TLS_v0.24.md](TLS_v0.24.md) — HTTPS support via `rustls` using `howls` with a
+  certificate loading example.
 - [TESTING_v0.24.md](TESTING_v0.24.md) — debug-only in-memory harness for calling routes.
 - [WS_v0.24.md](WS_v0.24.md) — upgrading connections to WebSockets with
   Workers and Lambda adapters.

--- a/docs/TLS_v0.24.md
+++ b/docs/TLS_v0.24.md
@@ -1,7 +1,8 @@
 # TLS Support
 
-The `tls` feature enables HTTPS servers using [rustls](https://github.com/rustls).
-It requires the `rt_tokio` runtime and wraps each TCP connection in
+The `tls` feature enables HTTPS servers using
+[rustls](https://github.com/rustls).  It requires the `rt_tokio` runtime and
+wraps each TCP connection in
 [`TlsStream`](../ohkami-0.24/ohkami/src/tls/mod.rs). `TlsStream` implements the
 `Connection` trait consumed by `Session`.
 
@@ -23,6 +24,41 @@ async fn main() {
         "/".GET(|| async {"secure"})
     )).howls("0.0.0.0:8443", tls_config).await;
 }
+```
+
+## Building the TLS config
+
+Loading certificates mirrors the snippet in the crate README.  Install the
+`ring` provider then parse your files with `rustls_pemfile`:
+
+```rust,no_run
+use rustls::ServerConfig;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use std::fs::File;
+use std::io::BufReader;
+
+rustls::crypto::ring::default_provider().install_default()
+    .expect("install ring provider");
+
+let cert_file = File::open("server.crt")?;
+let key_file  = File::open("server.key")?;
+
+let cert_chain = rustls_pemfile::certs(&mut BufReader::new(cert_file))
+    .map(|cd| cd.map(CertificateDer::from))
+    .collect::<Result<Vec<_>, _>>()?;
+
+let key = rustls_pemfile::read_one(&mut BufReader::new(key_file))?
+    .map(|p| match p {
+        rustls_pemfile::Item::Pkcs1Key(k) => PrivateKeyDer::Pkcs1(k),
+        rustls_pemfile::Item::Pkcs8Key(k) => PrivateKeyDer::Pkcs8(k),
+        _ => panic!("unexpected key type"),
+    })
+    .expect("private key");
+
+let tls_config = ServerConfig::builder()
+    .with_no_client_auth()
+    .with_single_cert(cert_chain, key)
+    .expect("TLS config");
 ```
 
 `howls` performs the TLS handshake using `tokio_rustls::TlsAcceptor` and serves


### PR DESCRIPTION
## Summary
- flesh out TLS guide with certificate loading steps
- link to this example from docs README
- note TLS example in docs roadmap

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_b_6864b81d9514832e8ef430b6bd94bf76