### PR TITLE
Expand util streaming docs

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -50,7 +50,8 @@ including connection trait details.
   [RUNTIME_ADAPTERS_v0.24](RUNTIME_ADAPTERS_v0.24.md) now include
   examples for `#[bindings]` (with env selection) and Lambda WebSocket handling.
 - `util` helpers and the `ohkami_lib` crate covered in [UTILS_v0.24](UTILS_v0.24.md)
-  now document base64 utilities, cookie parsing, `timeout_in` and a stream queue example.
+  now document base64 utilities, cookie parsing, `timeout_in` and streaming helpers
+  like `stream::queue`, `stream::once` and `StreamExt` combinators.
 - Error conversions via `IntoResponse` documented in
   [ERROR_HANDLING_v0.24](ERROR_HANDLING_v0.24.md).
 - Procedural macros in [MACROS_v0.24](MACROS_v0.24.md) now include examples for

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,9 +18,10 @@ For a quick project overview, see the main
   including the `Connection` trait and timeout control.
 - [RUNTIME_ADAPTERS_v0.24.md](RUNTIME_ADAPTERS_v0.24.md) — deploying to
   Workers or Lambda with examples, including Lambda WebSocket support.
-- [UTILS_v0.24.md](UTILS_v0.24.md) — helper functions such as base64 utilities,
-  cookie parsing, `timeout_in` and the `stream::queue` example covering slice,
-  num and time modules.
+- [UTILS_v0.24.md](UTILS_v0.24.md) — helper functions like base64 encoding,
+  cookie parsing and `timeout_in` plus streaming helpers such as `stream::queue`
+  and `stream::once` with `StreamExt` combinators. Covers slice, num and time
+  modules too.
 - [MACROS_v0.24.md](MACROS_v0.24.md) — derives plus OpenAPI and Workers macros
   including `#[bindings(env)]` for environment specific bindings.
 - [FANGS_v0.24.md](FANGS_v0.24.md) — overview of builtin middleware and

--- a/docs/UTILS_v0.24.md
+++ b/docs/UTILS_v0.24.md
@@ -66,7 +66,9 @@ These helpers keep Ohkami lightweight while avoiding extra dependencies in user 
 
 ### Additional Modules
 
-- `stream` – async helpers like `queue` and `StreamExt` used by SSE and examples.
+- `stream` – async helpers including `queue` and `once` plus the `StreamExt` trait
+  with `map`, `filter`, `chain` and `next` combinators. Used by SSE and the
+  examples.
 - `slice` and `CowSlice` – manual byte slice types for zero-copy operations.
 - `num` – `itoa` and `hexized` for efficient number formatting.
 - `time` – `imf_fixdate` to produce RFC 9110 date strings.
@@ -90,6 +92,17 @@ async fn events() -> DataStream {
         }
     }))
 }
+```
+
+Other utilities include `stream::once` for a single item and `StreamExt` for
+common combinators. A small stream pipeline could look like:
+
+```rust,no_run
+use ohkami::util::{stream, StreamExt};
+
+let mut s = stream::once(1).chain(stream::once(2)).map(|n| n * 2);
+assert_eq!(s.next().await, Some(2));
+assert_eq!(s.next().await, Some(4));
 ```
 
 See [`ohkami_lib/src/stream.rs`](../ohkami-0.24/ohkami_lib/src/stream.rs) for


### PR DESCRIPTION
## Summary
- describe `stream::once` and `StreamExt` helpers in the util docs
- mention these helpers in README and DOCS_ROADMAP

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_b_68653e651a90832eb09c1fe1bec8843f