### PR TITLE
docs: mention openapi support for Dir

### DIFF
--- a/docs/DIR_v0.24.md
+++ b/docs/DIR_v0.24.md
@@ -74,3 +74,11 @@ async fn main() {
 
 This serves `index.html` at `/` and `/about.html` at `/about`. Dotfiles under
 `./public` are accessible.
+
+## OpenAPI Support
+
+When the optional `openapi` feature is enabled the `Dir` fang registers
+`GET` operations for its mounted files. Generated paths include `200 OK`
+and `304 Not Modified` responses with the correct MIME type. Calling
+`Ohkami::generate` will therefore document static assets alongside your
+API routes.

--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -11,7 +11,7 @@ It highlights which modules are documented and notes areas that still need work.
   [CODING_GUIDE_v0.24](CODING_GUIDE_v0.24.md) and
   [PATTERNS_v0.24](PATTERNS_v0.24.md).
 - `ohkami/src/testing` — explained in [TESTING_v0.24](TESTING_v0.24.md).
-- `ohkami/src/tls` — usage documented in [TLS_v0.24](TLS_v0.24.md) with certificate loading example.
+- `ohkami/src/tls` — HTTPS in [TLS_v0.24](TLS_v0.24.md), with certificate loading example.
 - `ohkami/src/request` and `ohkami/src/response` - detailed in
   [REQUEST_v0.24](REQUEST_v0.24.md) (context store and payload limits) and
   [RESPONSE_v0.24](RESPONSE_v0.24.md) (body helpers and typed statuses).
@@ -26,7 +26,7 @@ It highlights which modules are documented and notes areas that still need work.
 - General conventions such as module layout, prelude imports and routing
   helpers documented in [CODE_STYLE_v0.24](CODE_STYLE_v0.24.md).
 - `ohkami/src/ohkami/dir` — static file serving in [DIR_v0.24](DIR_v0.24.md),
- including notes on preloading, compression and cache headers.
+ including notes on preloading, compression and cache headers and automatic OpenAPI responses.
 - `ohkami/src/config` â environment variables documented in
   [CONFIGURATION_v0.24](CONFIGURATION_v0.24.md). Values are loaded once at
   startup through the [`CONFIG`](../ohkami-0.24/ohkami/src/config.rs) static.

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,8 @@ For a quick project overview, see the main
 - [HEADERS_v0.24.md](HEADERS_v0.24.md) — common header utilities with `QValue`
   and compression helpers plus `SetCookie` parsing and builder methods.
 - [DIR_v0.24.md](DIR_v0.24.md) — static directory fang with preloading,
-  compression and caching details.
+  compression and caching details. With the `openapi` feature enabled
+  these files appear in the generated spec as `GET` operations.
 - [REQUEST_v0.24.md](REQUEST_v0.24.md) — request structure, context store and extraction.
 - [RESPONSE_v0.24.md](RESPONSE_v0.24.md) — building responses.
 - [ERROR_HANDLING_v0.24.md](ERROR_HANDLING_v0.24.md) — custom error enums and


### PR DESCRIPTION
## Summary
- note OpenAPI integration for the `Dir` fang
- reference this behavior in the docs index
- update the roadmap to mention automatic OpenAPI responses

## Testing
- `cargo check -q`

------
https://chatgpt.com/codex/tasks/task_b_68684b6fb4e8832ea672369a5579515b