### PR TITLE
Update SSE docs with implementation notes

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -93,8 +93,8 @@ including connection trait details.
 Router internals are now covered in more detail with notes on automatic
 `OPTIONS` handlers, merging nested `Ohkami`s and native runtime compression.
 The WebSocket guide shows `upgrade_durable` and the `SessionMap` helper for
-Workers. The `sse` module covers `DataStream::new`, queue‑based streaming and
-custom `Data` implementations. Further real‑world guides for the `Dir` fang
+Workers. The `sse` module now explains how `DataStream` is built on a queued
+stream and references the source for `handle::Stream`. Further real‑world guides for the `Dir` fang
 would be valuable.
 
 Additional gaps:

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,8 @@ For a quick project overview, see the main
 - [WS_v0.24.md](WS_v0.24.md) — upgrading connections to WebSockets with
   Workers and Lambda adapters.
 - [SSE_v0.24.md](SSE_v0.24.md) — streaming Server‑Sent Events with the
-  `DataStream` queue and custom `Data` types.
+  `DataStream` queue and custom `Data` types. Includes implementation notes
+  describing how the queue interacts with `Response`.
 - [ROUTER_v0.24.md](ROUTER_v0.24.md) — how routes are organized and finalized.
 - [FEATURE_FLAGS_v0.24.md](FEATURE_FLAGS_v0.24.md) — optional Cargo features
   detailing runtime and protocol flags.

--- a/docs/SSE_v0.24.md
+++ b/docs/SSE_v0.24.md
@@ -84,3 +84,17 @@ async fn main() {
     Ohkami::new(("/events".GET(stream))).howl("localhost:3030").await;
 }
 ```
+
+## Implementation Notes
+
+`DataStream` wraps a boxed `Stream<Item = String>` and a marker for the original
+data type. Its definition appears around lines 38‑41 of
+[`sse/mod.rs`](../ohkami-0.24/ohkami/src/sse/mod.rs#L38-L41). When converted into
+a response, `into_response` sets this stream on `Response::OK` without any
+additional boxing. See lines 66‑72 for the details.
+
+`DataStream::new` creates an internal queue using
+`QueueStream::new` and hands a [`handle::Stream`](../ohkami-0.24/ohkami/src/sse/mod.rs#L126-L143)
+to your closure. Each call to `send` pushes an encoded item onto this queue,
+which is then pulled by the streaming response. The closure runs to completion
+while the client receives each item in order.


### PR DESCRIPTION
## Summary
- add implementation notes to SSE guide
- mention the SSE internals in docs README
- update docs roadmap with SSE coverage details

## Testing
- `awk '{if(length($0)>100) print NR, length($0), $0}' docs/SSE_v0.24.md`
- `awk '{if(length($0)>100) print NR, length($0), $0}' docs/README.md`
- `awk '{if(length($0)>100) print NR, length($0), $0}' docs/DOCS_ROADMAP.md`

------
https://chatgpt.com/codex/tasks/task_b_686936e6f958832eb40b5e162ccd739a