### PR TITLE
Document header utilities

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -37,9 +37,10 @@ It highlights which modules are documented and notes areas that still need work.
 
 - `ohkami/src/format` explained in [FORMAT_v0.24](FORMAT_v0.24.md)
   with a custom CSV example.
-- `ohkami/src/header` described in [HEADERS_v0.24](HEADERS_v0.24.md)
-  including typed header wrappers, `SetCookie` builder methods and parsing,
-  cookie iteration and precompressed file detection.
+ - `ohkami/src/header` described in [HEADERS_v0.24](HEADERS_v0.24.md)
+   including typed header wrappers, `SetCookie` builder methods,
+   cookie iteration, precompressed file detection and the
+   `CompressionEncoding::to_extension`/`to_content_encoding` helpers.
 - `ohkami/src/ws` covered in [WS_v0.24](WS_v0.24.md)
   with `upgrade_durable`, `SessionMap`, split connections
   and the `LambdaWebSocket` helper for API Gateway.

--- a/docs/HEADERS_v0.24.md
+++ b/docs/HEADERS_v0.24.md
@@ -52,6 +52,18 @@ let sc = SetCookie::from_raw(raw)?;
 assert_eq!(sc.MaxAge(), Some(30));
 ```
 
+### Reading Cookies
+
+Incoming requests expose a `Cookies()` helper that splits the raw `Cookie`
+header into `(name, value)` pairs using
+[`util::iter_cookies`](../ohkami-0.24/ohkami/src/util.rs):
+
+```rust
+for (name, val) in req.headers.Cookies() {
+    println!("{name} = {val}");
+}
+```
+
 
 ## Entity Tags
 `ETag` parses strong and weak entity tags.  Use `ETag::parse` or the iterator
@@ -79,8 +91,22 @@ It returns the remaining path with extensions removed so pre-compressed assets
 like `app.js.gz.br` can be served with the correct `Content-Encoding` header.
 `Dir` uses this helper to look up files preferred by `Accept-Encoding`.
 
+`CompressionEncoding` can also reconstruct names:
 
+- `to_extension()` turns the encoding list back into a file extension such as
+  `"gz.br"`.
+- `to_content_encoding()` returns the header string like `"gzip, br"`.
 
+```rust
+use ohkami::header::CompressionEncoding;
+use std::path::Path;
+
+let (enc, path) = CompressionEncoding::from_file_path(Path::new("app.js.gz.br"))
+    .unwrap();
+assert_eq!(path.as_path(), Path::new("app.js"));
+assert_eq!(enc.to_extension(), "gz.br");
+assert_eq!(enc.to_content_encoding(), "gzip, br");
+```
 
 ### Example
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,8 +27,9 @@ For a quick project overview, see the main
 - [FANGS_v0.24.md](FANGS_v0.24.md) — overview of builtin middleware and
   configuration options.
 - [FORMAT_v0.24.md](FORMAT_v0.24.md) — request/response body helpers and custom format examples.
-- [HEADERS_v0.24.md](HEADERS_v0.24.md) — common header utilities with `QValue`
-  and compression helpers plus `SetCookie` parsing and builder methods.
+- [HEADERS_v0.24.md](HEADERS_v0.24.md) — common header utilities with `QValue`,
+  cookie iteration and compression helpers including `to_extension` plus
+  `SetCookie` parsing and builder methods.
 - [DIR_v0.24.md](DIR_v0.24.md) — static directory fang with preloading,
   compression and caching details. With the `openapi` feature enabled
   these files appear in the generated spec as `GET` operations.


### PR DESCRIPTION
## Summary
- add cookie iteration section to HEADERS guide
- document `CompressionEncoding` helpers
- mention new content in README and roadmap

## Testing
- `cargo check --manifest-path ohkami-0.24/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_b_6869387b6d38832e96f5be497ce08d92