### PR TITLE
Improve session docs

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -47,7 +47,7 @@ It highlights which modules are documented and notes areas that still need work.
   and the `LambdaWebSocket` helper for API Gateway.
 
 - `ohkami/src/session` - lifecycle explained in [SESSION_v0.24](SESSION_v0.24.md)
-including connection trait details.
+  including connection trait details and environment timeouts.
 - Cloud runtime adapters (`x_worker`, `x_lambda`) documented in
   [RUNTIME_ADAPTERS_v0.24](RUNTIME_ADAPTERS_v0.24.md) now include
   examples for `#[bindings]` (with env selection) and Lambda WebSocket handling.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ For a quick project overview, see the main
   typed errors and custom path parameters.
 - [ARCHITECTURE_v0.24.md](ARCHITECTURE_v0.24.md) — crate layout and runtime abstraction.
 - [SESSION_v0.24.md](SESSION_v0.24.md) — how connections are managed,
-  including the `Connection` trait and timeout control.
+  including the `Connection` trait, timeout control and the `OHKAMI_REQUEST_BUFSIZE` setting.
 - [RUNTIME_ADAPTERS_v0.24.md](RUNTIME_ADAPTERS_v0.24.md) — deploying to
   Workers or Lambda with examples, including Lambda WebSocket support.
 - [UTILS_v0.24.md](UTILS_v0.24.md) — helper functions like base64 encoding,

--- a/docs/SESSION_v0.24.md
+++ b/docs/SESSION_v0.24.md
@@ -1,10 +1,19 @@
 # Session Handling
 
-Ohkami processes each network connection through a `Session` struct. The implementation lives in [`ohkami/src/session`](../ohkami-0.24/ohkami/src/session/mod.rs).
+Ohkami processes each network connection through a `Session` struct.
+Its implementation lives in
+[`ohkami/src/session`](../ohkami-0.24/ohkami/src/session/mod.rs).
 
-A session owns the underlying TCP stream (or other runtime connection type) and drives the request/response loop. It applies a keep‑alive timeout between reads and routes each request through the shared `Router`. When the `ws` feature is enabled, a successful upgrade switches the session over to `WebSocket` management.
+A session owns the underlying TCP stream (or other runtime connection type)
+and drives the request/response loop. It applies a keep‑alive timeout between
+reads and routes each request through the shared `Router`. When the `ws`
+feature is enabled a successful upgrade switches the session over to
+`WebSocket` management.
 
-The module is compiled only for native runtimes (`__rt_native__`). `Session` is generic over a connection type implementing `AsyncRead` and `AsyncWrite`. `TcpStream` provides the default `Connection` implementation which can be upgraded to a WebSocket when the `ws` feature is enabled.
+The module is compiled only for native runtimes (`__rt_native__`). `Session`
+is generic over a connection type implementing `AsyncRead` and `AsyncWrite`.
+`TcpStream` provides the default `Connection` implementation which can be
+upgraded to a WebSocket when the `ws` feature is enabled.
 
 ```rust
 pub(crate) struct Session<C> {
@@ -21,10 +30,14 @@ pub(crate) trait Connection: AsyncRead + AsyncWrite + Unpin {
 
 Key behaviors:
 
-- Reads requests with `timeout_in` so idle connections close after `OHKAMI_KEEPALIVE_TIMEOUT` seconds.
+- Reads requests with `timeout_in` so idle connections close after
+  `OHKAMI_KEEPALIVE_TIMEOUT` seconds.
 - Catches panics from handlers and converts them into `500` responses.
-- Logs connection errors and broken pipes with the utility macros from [`util`](../ohkami-0.24/ohkami/src/util.rs).
-- When upgraded to a WebSocket, delegates to `ws::WebSocket` with its own timeout (`OHKAMI_WEBSOCKET_TIMEOUT`).
+- Logs connection errors and broken pipes using macros from
+  [`util`](../ohkami-0.24/ohkami/src/util.rs).
+- When upgraded to a WebSocket, delegates to `ws::WebSocket` with its own
+  timeout (`OHKAMI_WEBSOCKET_TIMEOUT`).
+- The request buffer size comes from `OHKAMI_REQUEST_BUFSIZE` which defaults to `2048` bytes.
 
 ## Request/Response Loop
 
@@ -44,4 +57,5 @@ Errors while writing to the socket are printed via `WARNING!` or `ERROR!` and
 terminate the session. This helps surface issues such as broken pipes while not
 crashing the server process.
 
-The session module is internal but understanding it helps when customizing runtimes or debugging low‑level behavior.
+The session module is internal but understanding it helps when customizing
+runtimes or debugging low‑level behavior.


### PR DESCRIPTION
## Summary
- expand `SESSION_v0.24.md` with request buffer note and split long lines
- mention `OHKAMI_REQUEST_BUFSIZE` in docs README
- update roadmap entry for the session module

## Testing
- `awk '{ if(length>100) print NR, length }' docs/SESSION_v0.24.md`
- `awk '{ if(length>100) print NR, length }' docs/README.md`
- `awk '{ if(length>100) print NR, length }' docs/DOCS_ROADMAP.md`

------
https://chatgpt.com/codex/tasks/task_b_686b0bb54358832e936aa24e5c90f5ac