### PR TITLE
Improve SSE docs

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -96,7 +96,7 @@ Router internals are now covered in more detail with notes on automatic
 `OPTIONS` handlers, merging nested `Ohkami`s and native runtime compression.
 The WebSocket guide shows `upgrade_durable` and the `SessionMap` helper for
 Workers. The `sse` module now explains how `DataStream` is built on a queued
-stream and references the source for `handle::Stream`. Further real‑world guides for the `Dir` fang
+stream, shows converting existing streams with `DataStream::from` and references the source lines for `handle::Stream`. Further real‑world guides for the `Dir` fang
 would be valuable.
 
 Additional gaps:

--- a/docs/SSE_v0.24.md
+++ b/docs/SSE_v0.24.md
@@ -98,3 +98,17 @@ additional boxing. See lines 66‑72 for the details.
 to your closure. Each call to `send` pushes an encoded item onto this queue,
 which is then pulled by the streaming response. The closure runs to completion
 while the client receives each item in order.
+
+## Source Highlights
+
+The [`DataStream`](../ohkami-0.24/ohkami/src/sse/mod.rs#L38-L41) type
+is defined as a thin wrapper around a boxed [`Stream`](../ohkami-0.24/ohkami_lib/src/stream.rs)
+and a marker for the data element.  The `From` implementation at
+[lines 84‑89](../ohkami-0.24/ohkami/src/sse/mod.rs#L84-L89) converts any
+`Stream<Item = T>` where `T: Data` into a `DataStream` by mapping each item
+through `Data::encode`.
+
+`DataStream::new` ([lines 93‑123](../ohkami-0.24/ohkami/src/sse/mod.rs#L93-L123))
+spawns an async producer backed by a `QueueStream`.  It returns immediately
+and yields items to the client as they are pushed via
+[`handle::Stream::send`](../ohkami-0.24/ohkami/src/sse/mod.rs#L126-L143).


### PR DESCRIPTION
## Summary
- document `DataStream` implementation details
- update roadmap note about SSE docs

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_b_686dbac12354832ea30c4734b3d69488