### PR TITLE
Improve header docs with ETag parsing

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -38,8 +38,8 @@ It highlights which modules are documented and notes areas that still need work.
 - `ohkami/src/format` explained in [FORMAT_v0.24](FORMAT_v0.24.md)
   with a custom CSV example.
  - `ohkami/src/header` described in [HEADERS_v0.24](HEADERS_v0.24.md)
-  including typed header wrappers, `SetCookie` builder methods,
-  cookie iteration, precompressed file detection,
+  covering typed header wrappers, `SetCookie` builder methods, `ETag`
+  iterators and comparison, cookie iteration, precompressed file detection,
   `AcceptEncoding::parse` details and the
   `CompressionEncoding::to_extension`/`to_content_encoding` helpers.
 - `ohkami/src/ws` covered in [WS_v0.24](WS_v0.24.md)

--- a/docs/HEADERS_v0.24.md
+++ b/docs/HEADERS_v0.24.md
@@ -66,10 +66,25 @@ for (name, val) in req.headers.Cookies() {
 
 
 ## Entity Tags
-`ETag` parses strong and weak entity tags.  Use `ETag::parse` or the iterator
-helpers to process conditional request headers.
+`ETag` parses strong and weak entity tags. Use `ETag::parse` or the iterator
+helpers to process conditional request headers. `ETag::iter_from` skips invalid
+values and `try_iter_from` returns errors. The `matches` method implements the
+weak comparison defined by HTTP.
 It also implements `Display` so headers can be generated with
-`res.headers.set().ETag(etag.clone());`.
+`res.headers.set().ETag(etag.clone());`
+
+### Example
+
+```rust
+use ohkami::header::ETag;
+
+let ours = ETag::strong("v1".into());
+for tag in ETag::iter_from(r#"W/"v1", "v2""#) {
+    if tag.matches(&ours) {
+        // send 304 Not Modified
+    }
+}
+```
 
 ## Content Encoding
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,8 +29,9 @@ For a quick project overview, see the main
   configuration options.
 - [FORMAT_v0.24.md](FORMAT_v0.24.md) — request/response body helpers and custom format examples.
 - [HEADERS_v0.24.md](HEADERS_v0.24.md) — common header utilities with `QValue`,
-  cookie iteration and compression helpers including `to_extension` plus
-  `SetCookie` builder methods and `AcceptEncoding::parse` behavior.
+  cookie iteration, `ETag` parsing and comparison helpers, compression helpers
+  including `CompressionEncoding::to_extension`, plus `SetCookie` builder
+  methods and `AcceptEncoding::parse` behavior.
 - [DIR_v0.24.md](DIR_v0.24.md) — static directory fang with preloading,
   compression and caching details. With the `openapi` feature enabled
   these files appear in the generated spec as `GET` operations.


### PR DESCRIPTION
## Summary
- document ETag parsing helpers and weak matching
- mention ETag helpers in README
- update roadmap to reference ETag docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6879f477aed0832ebd7eef550bddbc49