### PR TITLE
Update CORS doc

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -7,7 +7,8 @@ It highlights which modules are documented and notes areas that still need work.
 
 - `ohkami/src/ohkami` â explained throughout [CODING_GUIDE_v0.24](CODING_GUIDE_v0.24.md).
 - `ohkami/src/fang` â builtin middleware covered in
-  [FANGS_v0.24](FANGS_v0.24.md) (builder method details added),
+  [FANGS_v0.24](FANGS_v0.24.md) (builder method details added; CORS docs clarify
+  that allowed methods are auto-detected),
   [CODING_GUIDE_v0.24](CODING_GUIDE_v0.24.md) and
   [PATTERNS_v0.24](PATTERNS_v0.24.md).
 - `ohkami/src/testing` — explained in [TESTING_v0.24](TESTING_v0.24.md).

--- a/docs/FANGS_v0.24.md
+++ b/docs/FANGS_v0.24.md
@@ -64,7 +64,8 @@ let token = JWT::<Claims>::new_256("topsecret")
 `CORS::new(origin)` configures `Access-Control-*` headers for cross origin
 requests.  Methods like `.AllowCredentials()` and `.AllowHeaders([...])`
 customize the response to pre‑flight and normal requests.  Use
-`ExposeHeaders`, `MaxAge` and `AllowMethods` to fine tune the headers.
+`ExposeHeaders` and `MaxAge` to tune caching behavior.  The allowed methods
+list is detected automatically from the routes defined at that path.
 
 ```rust,no_run
 use ohkami::fang::CORS;

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,8 @@ For a quick project overview, see the main
   helpers. Describes `#[bindings(env)]` and worker metadata options for
   automatic documentation.
 - [FANGS_v0.24.md](FANGS_v0.24.md) — overview of builtin middleware and
-  configuration options.
+  configuration options. Notes that `CORS` automatically selects allowed
+  methods based on the defined routes.
 - [FORMAT_v0.24.md](FORMAT_v0.24.md) — request/response body helpers and custom format examples.
 - [HEADERS_v0.24.md](HEADERS_v0.24.md) — common header utilities with `QValue`,
   cookie iteration, `ETag` parsing and comparison helpers, compression helpers


### PR DESCRIPTION
## Summary
- clarify that `AllowMethods` is not currently exposed in the CORS fang
- mention automatic method detection in `docs/README.md`
- update the docs roadmap entry for FANGS

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_b_687bf584fcf8832eb93c9a8443181e9a