### PR TITLE
Improve configuration docs

### DIFF
--- a/docs/CONFIGURATION_v0.24.md
+++ b/docs/CONFIGURATION_v0.24.md
@@ -18,3 +18,21 @@ These options are only used with native runtimes such as `rt_tokio` or `rt_smol`
 Values are parsed once using `LazyLock`. Invalid or missing variables fall back
 to the defaults above. Increase these numbers if clients send large headers or
 WebSocket connections should persist longer.
+
+The static [`CONFIG`](../ohkami-0.24/ohkami/src/lib.rs#L171-L176) stores these
+values. Each environment variable is parsed in
+[`config.rs`](../ohkami-0.24/ohkami/src/config.rs#L33-L61) using
+`LazyLock` so the values never change after startup.
+
+Usage in the source:
+
+- `OHKAMI_REQUEST_BUFSIZE` determines the buffer size allocated in
+  [`Request::init`](../ohkami-0.24/ohkami/src/request/mod.rs#L186-L204).
+  Warnings at
+  [lines 266‑281](../ohkami-0.24/ohkami/src/request/mod.rs#L266-L281)
+  suggest increasing it if headers exceed the limit.
+- `OHKAMI_KEEPALIVE_TIMEOUT` controls the timeout passed to
+  [`timeout_in`](../ohkami-0.24/ohkami/src/session/mod.rs#L70-L83)
+  when reading each request.
+- `OHKAMI_WEBSOCKET_TIMEOUT` sets the duration for WebSocket sessions in
+  [`Session::manage`](../ohkami-0.24/ohkami/src/session/mod.rs#L130-L147).

--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -28,9 +28,10 @@ It highlights which modules are documented and notes areas that still need work.
   helpers documented in [CODE_STYLE_v0.24](CODE_STYLE_v0.24.md).
 - `ohkami/src/ohkami/dir` — static file serving in [DIR_v0.24](DIR_v0.24.md),
  including notes on preloading, compression and cache headers and automatic OpenAPI responses.
-- `ohkami/src/config` â environment variables documented in
-  [CONFIGURATION_v0.24](CONFIGURATION_v0.24.md). Values are loaded once at
-  startup through the [`CONFIG`](../ohkami-0.24/ohkami/src/config.rs) static.
+- `ohkami/src/config` â environment variables documented in
+  [CONFIGURATION_v0.24](CONFIGURATION_v0.24.md). The guide now links to the
+  [`CONFIG`](../ohkami-0.24/ohkami/src/lib.rs#L171-L176) static and explains
+  where each variable is used within the request and session modules.
 - `ohkami/src/router` â tree structure, compression and lookup documented in
   [ROUTER_v0.24](ROUTER_v0.24.md).
 - Notes in [NOTES_FROM_SOURCE_v0.24.md](NOTES_FROM_SOURCE_v0.24.md) cover router defaults.

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,7 +59,8 @@ For a quick project overview, see the main
   sample results and comparisons of header containers and `TupleMap` lookups.
   including header container and `TupleMap` comparisons.
 
-- [CONFIGURATION_v0.24.md](CONFIGURATION_v0.24.md) — environment variables and runtime tuning.
+- [CONFIGURATION_v0.24.md](CONFIGURATION_v0.24.md) — environment variables with
+  source links explaining how each value is used.
 - [DOCS_ROADMAP.md](DOCS_ROADMAP.md) — what parts of the source have been documented so far.
 - [DOCS_TODO_v0.24.md](DOCS_TODO_v0.24.md) — checklist for verifying each guide.
 - [FEATURE_REQUESTS.md](FEATURE_REQUESTS.md) — ideas for future improvements.


### PR DESCRIPTION
## Summary
- expand environment variable guide with source references
- update README bullet for configuration guide
- note config links in DOCS_ROADMAP

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687bf733cbd4832e8426025e0210bfb0