### PR TITLE
Update utils guide

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -55,7 +55,8 @@ It highlights which modules are documented and notes areas that still need work.
   examples for `#[bindings]` (with env selection) and Lambda WebSocket handling.
 - `util` helpers and the `ohkami_lib` crate covered in [UTILS_v0.24](UTILS_v0.24.md)
   now document base64 utilities, cookie parsing, `timeout_in` and streaming helpers
-  like `stream::queue`, `stream::once` and `StreamExt` combinators.
+  like `stream::queue`, `stream::once` and `StreamExt` combinators. The guide
+  now also notes the `num_cpus` re-export for glommio runtime builds.
 - Error conversions via `IntoResponse` documented in
   [ERROR_HANDLING_v0.24](ERROR_HANDLING_v0.24.md).
  - Procedural macros in [MACROS_v0.24](MACROS_v0.24.md) now include examples for

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ For a quick project overview, see the main
 - [UTILS_v0.24.md](UTILS_v0.24.md) — helper functions like base64 encoding,
   cookie parsing and `timeout_in` plus streaming helpers such as `stream::queue`
   and `stream::once` with `StreamExt` combinators. Covers slice, num and time
-  modules too.
+  modules too, and notes the `num_cpus` re-export for glommio runtimes.
 - [MACROS_v0.24.md](MACROS_v0.24.md) — derives plus OpenAPI macros and Workers
   helpers. Describes `#[bindings(env)]` and worker metadata options for
   automatic documentation.

--- a/docs/UTILS_v0.24.md
+++ b/docs/UTILS_v0.24.md
@@ -52,6 +52,7 @@ Other helpers include:
 - `ErrorMessage` — simple error type implementing `IntoResponse` for 500s.
 - `imf_fixdate` formats timestamps for HTTP `Date` headers.
 - `IP_0000` constant representing `0.0.0.0` for binding servers.
+- `num_cpus` re-export when using the `rt_glommio` runtime for core detection.
 
 ## ohkami_lib Crate
 


### PR DESCRIPTION
## Summary
- mention num_cpus in UTILS_v0.24
- update README and roadmap

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_b_6882a403e578832eb4d082197f990a3a