### PR TITLE
Update builtin fang docs

### DIFF
--- a/docs/DOCS_ROADMAP.md
+++ b/docs/DOCS_ROADMAP.md
@@ -8,7 +8,7 @@ It highlights which modules are documented and notes areas that still need work.
 - `ohkami/src/ohkami` â explained throughout [CODING_GUIDE_v0.24](CODING_GUIDE_v0.24.md).
 - `ohkami/src/fang` â builtin middleware covered in
   [FANGS_v0.24](FANGS_v0.24.md) (builder method details added; CORS docs clarify
-  that allowed methods are auto-detected),
+  that allowed methods are auto-detected; OpenAPI hooks for BasicAuth/JWT are noted),
   [CODING_GUIDE_v0.24](CODING_GUIDE_v0.24.md) and
   [PATTERNS_v0.24](PATTERNS_v0.24.md).
 - `ohkami/src/testing` — explained in [TESTING_v0.24](TESTING_v0.24.md).

--- a/docs/FANGS_v0.24.md
+++ b/docs/FANGS_v0.24.md
@@ -37,6 +37,11 @@ let secure = ohkami::Ohkami::new((
 ));
 ```
 
+When the `openapi` feature is active the fang marks protected handlers with a
+basic authentication requirement. The implementation at
+[lines 99‑103](../ohkami-0.24/ohkami/src/fang/builtin/basicauth.rs#L99-L103)
+adds `SecurityScheme::Basic("basicAuth")` to the OpenAPI spec.
+
 ## JWT
 
 `JWT::<Payload>::new_256(secret)` verifies a JSON Web Token and stores the
@@ -58,6 +63,10 @@ let api = ohkami::Ohkami::new((
 let token = JWT::<Claims>::new_256("topsecret")
     .issue(Claims { sub: "u1".into() });
 ```
+
+With `openapi` enabled the fang inserts a bearer security definition. The logic
+is implemented around
+[lines 116‑128](../ohkami-0.24/ohkami/src/fang/builtin/jwt.rs#L116-L128).
 
 ## CORS
 
@@ -84,6 +93,9 @@ let cors = CORS::new("https://example.com")
 `Timeout::by_secs(n)` aborts handlers that take longer than the specified
 duration on native runtimes.  Builders `by_millis`, `by_secs_f32` and
 `by_secs_f64` are also available.
+
+The constructor methods are defined in
+[timeout.rs](../ohkami-0.24/ohkami/src/fang/builtin/timeout.rs#L36-L52).
 
 ```rust,no_run
 use ohkami::fang::Timeout;

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,9 +25,10 @@ For a quick project overview, see the main
 - [MACROS_v0.24.md](MACROS_v0.24.md) — derives plus OpenAPI macros and Workers
   helpers. Describes `#[bindings(env)]` and worker metadata options for
   automatic documentation.
-- [FANGS_v0.24.md](FANGS_v0.24.md) — overview of builtin middleware and
-  configuration options. Notes that `CORS` automatically selects allowed
-  methods based on the defined routes.
+ - [FANGS_v0.24.md](FANGS_v0.24.md) — overview of builtin middleware and
+   configuration options. Notes that `CORS` automatically selects allowed
+   methods based on the defined routes and that `BasicAuth` and `JWT`
+   integrate with OpenAPI security schemes.
 - [FORMAT_v0.24.md](FORMAT_v0.24.md) — request/response body helpers and custom format examples.
 - [HEADERS_v0.24.md](HEADERS_v0.24.md) — common header utilities with `QValue`,
   cookie iteration, `ETag` parsing and comparison helpers, compression helpers


### PR DESCRIPTION
## Summary
- describe BasicAuth and JWT OpenAPI integration in `FANGS_v0.24`
- link timeout builder code
- mention security hooks in README and roadmap

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6882ac979a80832eb3edf0ac093ce099